### PR TITLE
Combine describe and describeid workflow commands

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -494,11 +494,7 @@ var flagsForQuery = append(flagsForStackTraceQuery,
 	})
 
 func getFlagsForDescribe() []cli.Flag {
-	return append(flagsForExecution, getFlagsForDescribeID()...)
-}
-
-func getFlagsForDescribeID() []cli.Flag {
-	return []cli.Flag{
+	return append(flagsForExecution, []cli.Flag{
 		&cli.BoolFlag{
 			Name:  FlagPrintRawWithAlias,
 			Usage: "Print properties as they are stored",
@@ -507,7 +503,7 @@ func getFlagsForDescribeID() []cli.Flag {
 			Name:  FlagResetPointsOnly,
 			Usage: "Only show auto-reset points",
 		},
-	}
+	}...)
 }
 
 func getFlagsForObserve() []cli.Flag {

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -193,17 +193,6 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:        "describeid",
-			Aliases:     []string{"descid"},
-			Usage:       "show information of workflow execution with given workflow_id and optional run_id (a shortcut of `describe -w <wid> -r <rid>`)",
-			Description: "tctl workflow describeid <workflow_id> <run_id>. workflow_id is required; run_id is optional",
-			Flags:       getFlagsForDescribeID(),
-			Action: func(c *cli.Context) error {
-				DescribeWorkflowWithID(c)
-				return nil
-			},
-		},
-		{
 			Name:    "observe",
 			Aliases: []string{"ob"},
 			Usage:   "show the progress of workflow history",

--- a/cli/workflowCommands.go
+++ b/cli/workflowCommands.go
@@ -66,17 +66,7 @@ import (
 
 // ShowHistory shows the history of given workflow execution based on workflowID and runID.
 func ShowHistory(c *cli.Context) {
-	var wid string
-	var rid string
-	if c.NArg() >= 1 {
-		wid = c.Args().First()
-		if c.NArg() >= 2 {
-			rid = c.Args().Get(1)
-		}
-	} else {
-		wid = getRequiredOption(c, FlagWorkflowID)
-		rid = c.String(FlagRunID)
-	}
+	wid, rid := getWorkflowParams(c)
 
 	namespace := getRequiredGlobalOption(c, FlagNamespace)
 	var maxFieldLength int
@@ -642,27 +632,8 @@ func ListArchivedWorkflow(c *cli.Context) {
 
 // DescribeWorkflow show information about the specified workflow execution
 func DescribeWorkflow(c *cli.Context) {
-	wid := getRequiredOption(c, FlagWorkflowID)
-	rid := c.String(FlagRunID)
+	wid, rid := getWorkflowParams(c)
 
-	describeWorkflowHelper(c, wid, rid)
-}
-
-// DescribeWorkflowWithID show information about the specified workflow execution
-func DescribeWorkflowWithID(c *cli.Context) {
-	if !c.Args().Present() {
-		ErrorAndExit("Argument workflow_id is required.", nil)
-	}
-	wid := c.Args().First()
-	rid := ""
-	if c.NArg() >= 2 {
-		rid = c.Args().Get(1)
-	}
-
-	describeWorkflowHelper(c, wid, rid)
-}
-
-func describeWorkflowHelper(c *cli.Context, wid, rid string) {
 	frontendClient := cFactory.FrontendClient(c)
 	namespace := getRequiredGlobalOption(c, FlagNamespace)
 	printRaw := c.Bool(FlagPrintRaw) // printRaw is false by default,
@@ -1464,6 +1435,22 @@ func ObserveHistoryWithID(c *cli.Context) {
 	}
 
 	printWorkflowProgress(c, wid, rid)
+}
+
+func getWorkflowParams(c *cli.Context) (string, string) {
+	var wid, rid string
+
+	if c.NArg() >= 1 {
+		wid = c.Args().First()
+		if c.NArg() >= 2 {
+			rid = c.Args().Get(1)
+		}
+	} else {
+		wid = getRequiredOption(c, FlagWorkflowID)
+		rid = c.String(FlagRunID)
+	}
+
+	return wid, rid
 }
 
 func listWorkflows(ctx context.Context, client workflowservice.WorkflowServiceClient, npt []byte, namespace string, query string) ([]interface{}, []byte, error) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Describe workflow command now can undestand `WorkflowId` and `RunId` paramaters as both arguments or flags
Removed `describeid` command
 
## Why?
<!-- Tell your future self why have you made these changes -->
UX improvements

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
