### PR TITLE
Combine observe and observeid workflow commands

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -507,11 +507,7 @@ func getFlagsForDescribe() []cli.Flag {
 }
 
 func getFlagsForObserve() []cli.Flag {
-	return append(flagsForExecution, getFlagsForObserveID()...)
-}
-
-func getFlagsForObserveID() []cli.Flag {
-	return []cli.Flag{
+	return append(flagsForExecution, []cli.Flag{
 		&cli.BoolFlag{
 			Name:  FlagShowDetailWithAlias,
 			Usage: "Optional show event details",
@@ -520,7 +516,7 @@ func getFlagsForObserveID() []cli.Flag {
 			Name:  FlagMaxFieldLengthWithAlias,
 			Usage: "Optional maximum length for each attribute field when show details",
 		},
-	}
+	}...)
 }
 
 func getDBFlags() []cli.Flag {

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -203,16 +203,6 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:    "observeid",
-			Aliases: []string{"obid"},
-			Usage:   "show the progress of workflow history with given workflow_id and optional run_id (a shortcut of `observe -w <wid> -r <rid>`)",
-			Flags:   getFlagsForObserveID(),
-			Action: func(c *cli.Context) error {
-				ObserveHistoryWithID(c)
-				return nil
-			},
-		},
-		{
 			Name:    "reset",
 			Aliases: []string{"rs"},
 			Usage:   "reset the workflow, by either eventId or resetType.",

--- a/cli/workflowCommands.go
+++ b/cli/workflowCommands.go
@@ -833,8 +833,7 @@ func scanWorkflowExecutions(sdkClient sdkclient.Client, pageSize int, nextPageTo
 
 // ObserveHistory show the process of running workflow
 func ObserveHistory(c *cli.Context) {
-	wid := getRequiredOption(c, FlagWorkflowID)
-	rid := c.String(FlagRunID)
+	wid, rid := getWorkflowParams(c)
 
 	printWorkflowProgress(c, wid, rid)
 }
@@ -1444,20 +1443,6 @@ func FailActivity(c *cli.Context) {
 	} else {
 		fmt.Println("Fail activity successfully.")
 	}
-}
-
-// ObserveHistoryWithID show the process of running workflow
-func ObserveHistoryWithID(c *cli.Context) {
-	if !c.Args().Present() {
-		ErrorAndExit("Argument workflow_id is required.", nil)
-	}
-	wid := c.Args().First()
-	rid := ""
-	if c.NArg() >= 2 {
-		rid = c.Args().Get(1)
-	}
-
-	printWorkflowProgress(c, wid, rid)
 }
 
 func getWorkflowParams(c *cli.Context) (string, string) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Observe workflow command now can undestand WorkflowId and RunId paramaters as both arguments or flags
Removed observe command

## Why?
<!-- Tell your future self why have you made these changes -->
UX improvement

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
