### PR TITLE
Allow tctl to start workflows with infinite timeout

### DIFF
--- a/cli/workflowCommands.go
+++ b/cli/workflowCommands.go
@@ -122,9 +122,6 @@ func RunWorkflow(c *cli.Context) {
 	taskQueue := getRequiredOption(c, FlagTaskQueue)
 	workflowType := getRequiredOption(c, FlagWorkflowType)
 	et := c.Int(FlagExecutionTimeout)
-	if et == 0 {
-		ErrorAndExit(fmt.Sprintf("Option %s format is invalid.", FlagExecutionTimeout), nil)
-	}
 	dt := c.Int(FlagWorkflowTaskTimeout)
 	wid := c.String(FlagWorkflowID)
 	if len(wid) == 0 {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
original change https://github.com/temporalio/temporal/pull/1602
Made `--execution_timeout` tctl flag optional, so that it is possible to start workflows with infinite execution timeout (execution_timeout = 0)

## Why?
<!-- Tell your future self why have you made these changes -->
Infinite execution timeout is a valid case and should be allowed
Fixes #1601 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
