### PR TITLE
Control enabling and disabling color through a single flag

### DIFF
--- a/terminal/color/color.go
+++ b/terminal/color/color.go
@@ -26,8 +26,19 @@ package color
 
 import (
 	"github.com/fatih/color"
-	"github.com/temporalio/tctl/terminal/flags"
 	"github.com/urfave/cli/v2"
+)
+
+const (
+	FlagColor = "color"
+)
+
+type ColorOption string
+
+const (
+	Auto   ColorOption = "auto"
+	Always ColorOption = "always"
+	Never  ColorOption = "never"
 )
 
 var (
@@ -37,26 +48,36 @@ var (
 )
 
 func Green(c *cli.Context, format string, a ...interface{}) string {
-	checkNoColor(c)
+	checkColor(c)
 	return colorGreen(format, a...)
 }
 
 func Magenta(c *cli.Context, format string, a ...interface{}) string {
-	checkNoColor(c)
+	checkColor(c)
 	return colorMagenta(format, a...)
 }
 
 func Yellow(c *cli.Context, format string, a ...interface{}) string {
-	checkNoColor(c)
+	checkColor(c)
 	return color.YellowString(format, a...)
 }
 func Red(c *cli.Context, format string, a ...interface{}) string {
-	checkNoColor(c)
+	checkColor(c)
 	return colorRed(format, a...)
 }
 
-func checkNoColor(c *cli.Context) {
-	if c.Bool(flags.FlagNoColor) {
+func checkColor(c *cli.Context) {
+	colorFlag := c.String(FlagColor)
+
+	colorVal := ColorOption(colorFlag)
+	switch colorVal {
+	case Always:
+		color.NoColor = false
+	case Never:
 		color.NoColor = true
+
+	default: // auto
+		// handled by color pkg
+		// tty - color. non-tty - false
 	}
 }

--- a/terminal/flags/flags.go
+++ b/terminal/flags/flags.go
@@ -26,10 +26,12 @@ package flags
 import (
 	"fmt"
 
+	"github.com/urfave/cli/v2"
+
+	"github.com/temporalio/tctl/terminal/color"
 	"github.com/temporalio/tctl/terminal/defs"
 	"github.com/temporalio/tctl/terminal/format"
 	"github.com/temporalio/tctl/terminal/timeformat"
-	"github.com/urfave/cli/v2"
 )
 
 // General command line flags
@@ -37,7 +39,6 @@ const (
 	FlagAll      = "all"
 	FlagDetach   = "detach"
 	FlagPageSize = "pagesize"
-	FlagNoColor  = "no-color"
 )
 
 var FlagsForPagination = []cli.Flag{
@@ -70,9 +71,11 @@ var FlagsForRendering = []cli.Flag{
 		Usage: fmt.Sprintf("format time as: %v, %v, %v.", timeformat.Relative, timeformat.ISO, timeformat.Raw),
 		Value: string(timeformat.Relative),
 	},
-	&cli.BoolFlag{
-		Name:  FlagNoColor,
-		Usage: "disable color output",
+	&cli.StringFlag{
+		Name:    color.FlagColor,
+		Aliases: []string{"c"},
+		Usage:   fmt.Sprintf("when to use color: %v, %v, %v.", color.Auto, color.Always, color.Never),
+		Value:   string(color.Auto),
 	},
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Implementation of proposal https://github.com/temporalio/proposals/pull/32

Allows to control whether to enable/disable coloring. Adds --color flag. 
Flag values:

- auto # enable color in tty, disables in non-tty
- always # enable in both tty and non-tty
- never # disable in both tty and non-tty 

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
`tctl workflow list --color <auto | always | never>`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
