### PR TITLE
Support printint time as Relative

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ replace go.temporal.io/server => /home/user0/server
 go 1.16
 
 require (
+	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.10.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/
 github.com/dgryski/go-farm v0.0.0-20140601200337-fc41e106ee0e/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WAFKLNi6ZS0675eEUC9y3AlwSbQu1Y=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/emirpasic/gods v0.0.0-20190624094223-e689965507ab/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/terminal/timeformat/timeformat.go
+++ b/terminal/timeformat/timeformat.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/urfave/cli/v2"
 
 	"github.com/temporalio/shared-go/timestamp"
@@ -55,7 +56,9 @@ func FormatTime(c *cli.Context, val *time.Time) string {
 		return timeVal.Format(time.RFC3339)
 	case Raw:
 		return fmt.Sprintf("%v", timeVal)
-	default: // Relative
-		return "6 hours ago"
+	case Relative:
+		return humanize.Time(timeVal)
+	default:
+		return humanize.Time(timeVal)
 	}
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds support for Relative time format (`1 hour ago`):

```bash
$ ./tctl workflow list
  EXECUTION WORKFLOWID            EXECUTION RUNID             STARTTIME   
  006e89ad###___4       092b8b08-06ee-44e7-a9f5-a99097ad9d45  1 hour ago  
  006e89ad###___3       16c39cbd-cb91-48a4-a261-3a112ff4f0e1  1 hour ago  
  006e89ad###___2       765c7a2b-a757-4997-aa6c-91bfaf839816  1 hour ago  
  006e89ad###___1       8b3e6beb-f22d-405e-a818-7a816bbb10b8  1 hour ago  
  36d2b23d###___4       87e6f336-2dd2-48c7-9791-d73e102cc691  1 hour ago  
  36d2b23d###___3       c4837a91-d83d-46da-a054-4dd9581635e6  1 hour ago  
```

## Why?
<!-- Tell your future self why have you made these changes -->
Improves readability of Time 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
