### PR TITLE
Remove deprecated workflow flags

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -407,29 +407,6 @@ var flagsForWorkflowFiltering = []cli.Flag{
 	},
 }
 
-var flagsForWorkflowRendering = []cli.Flag{
-	&cli.BoolFlag{
-		Name:  FlagPrintRawTimeWithAlias,
-		Usage: "Print raw timestamp",
-	},
-	&cli.BoolFlag{
-		Name:  FlagPrintDateTimeWithAlias,
-		Usage: "Print full date time in '2006-01-02T15:04:05Z07:00' format",
-	},
-	&cli.BoolFlag{
-		Name:  FlagPrintMemoWithAlias,
-		Usage: "Print memo",
-	},
-	&cli.BoolFlag{
-		Name:  FlagPrintSearchAttrWithAlias,
-		Usage: "Print search attributes",
-	},
-	&cli.BoolFlag{
-		Name:  FlagPrintFullyDetailWithAlias,
-		Usage: "Print full message without table format",
-	},
-}
-
 var flagsForScan = []cli.Flag{
 	&cli.StringFlag{
 		Name:  FlagListQueryWithAlias,

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -57,7 +57,7 @@ func newWorkflowCommands() []*cli.Command {
 			Aliases:     []string{"l"},
 			Usage:       "list open or closed workflow executions",
 			Description: "list one page (default size 10 items) by default, use flag --pagesize to change page size",
-			Flags:       append(append(flagsForWorkflowFiltering, flagsForWorkflowRendering...), flags.FlagsForPaginationAndRendering...),
+			Flags:       append(flagsForWorkflowFiltering, flags.FlagsForPaginationAndRendering...),
 			Action: func(c *cli.Context) error {
 				ListWorkflow(c)
 				return nil
@@ -66,7 +66,7 @@ func newWorkflowCommands() []*cli.Command {
 		{
 			Name:  "listarchived",
 			Usage: "list archived workflow executions",
-			Flags: append(append(flagsForListArchived, flagsForWorkflowRendering...), flags.FlagsForPaginationAndRendering...),
+			Flags: append(flagsForListArchived, flags.FlagsForPaginationAndRendering...),
 			Action: func(c *cli.Context) error {
 				ListArchivedWorkflow(c)
 				return nil
@@ -144,7 +144,7 @@ func newWorkflowCommands() []*cli.Command {
 			Name: "scan",
 			Usage: "scan workflow executions (need to enable Temporal server on ElasticSearch). " +
 				"It will be faster than listall, but result are not sorted.",
-			Flags: append(append(flagsForScan, flagsForWorkflowRendering...), flags.FlagsForPaginationAndRendering...),
+			Flags: append(flagsForScan, flags.FlagsForPaginationAndRendering...),
 			Action: func(c *cli.Context) error {
 				ScanAllWorkflow(c)
 				return nil

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -35,14 +35,14 @@ import (
 )
 
 var FlagsForPagination = []cli.Flag{
-	&cli.BoolFlag{
-		Name:  pager.FlagNoPager,
-		Usage: "disable interactive paging",
-	},
 	&cli.StringFlag{
 		Name:    pager.FlagPager,
 		Usage:   "pager to use: cat, less, favoritePager..",
 		EnvVars: []string{"PAGER"},
+	},
+	&cli.BoolFlag{
+		Name:  pager.FlagNoPager,
+		Usage: "disable interactive paging",
 	},
 	&cli.IntFlag{
 		Name:  pager.FlagPageSize,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Removed deprecated flags such as `--print_memo`, `--print_json`, `--print-raw-time`  in favor of new flags `--columns`, `--output`, `--format-time` etc. 

## Why?
<!-- Tell your future self why have you made these changes -->
Cleaning help output

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
