### PR TITLE
Print struct columns as json

### DIFF
--- a/pkg/format/time.go
+++ b/pkg/format/time.go
@@ -46,10 +46,10 @@ const (
 	Raw      FormatTimeOption = "raw"
 )
 
-func FormatTime(c *cli.Context, val *time.Time) string {
+func FormatTime(c *cli.Context, val time.Time) string {
 	formatFlag := c.String(FlagFormatTime)
 
-	timeVal := timestamp.TimeValue(val)
+	timeVal := timestamp.TimeValue(&val)
 	format := FormatTimeOption(formatFlag)
 	switch format {
 	case ISO:

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -33,18 +33,38 @@ import (
 )
 
 func PrintJSON(o interface{}, opts *PrintOptions) {
-	var b []byte
-	var err error
-	if pb, ok := o.(proto.Message); ok {
-		encoder := codec.NewJSONPBIndentEncoder("  ")
-		b, err = encoder.Encode(pb)
-	} else {
-		b, err = json.MarshalIndent(o, "", "  ")
-	}
+	json, err := ParseToJSON(o, true)
 
 	if err != nil {
 		fmt.Printf("Error when try to print pretty: %v\n", err)
 		fmt.Fprintln(opts.Pager, o)
 	}
-	fmt.Fprintln(opts.Pager, string(b))
+
+	fmt.Fprintln(opts.Pager, json)
+}
+
+func ParseToJSON(o interface{}, indent bool) (string, error) {
+	var b []byte
+	var err error
+	if pb, ok := o.(proto.Message); ok {
+		var encoder *codec.JSONPBEncoder
+		if indent {
+			encoder = codec.NewJSONPBIndentEncoder("  ")
+		} else {
+			encoder = codec.NewJSONPBEncoder()
+		}
+		b, err = encoder.Encode(pb)
+	} else {
+		if indent {
+			b, err = json.MarshalIndent(o, "", "  ")
+		} else {
+			b, err = json.Marshal(o)
+		}
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Makes columns that are of kind `struct` to be printed as json instead of raw go structure
```bash
$ ./tctl w l --columns "Execution","StartTime" --pager cat
                                     EXECUTION                                       STARTTIME   
  {"workflowId":"280910ff###___38","runId":"97e8caf9-34fa-4054-9ce3-8583fef43591"}  8 hours ago  
  {"workflowId":"280910ff###___39","runId":"7047eef8-0b4c-4ecc-8314-fe0dcab2fbe3"}  8 hours ago  
  {"workflowId":"280910ff###___30","runId":"daca6c00-284b-4af3-bb0c-dd8160aba9e2"}  8 hours ago  
  {"workflowId":"280910ff###___40","runId":"e5013753-ff7a-457d-9576-c3a9fcbde651"}  8 hours ago
```

## Why?
<!-- Tell your future self why have you made these changes -->
readability improvements

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
