### PR TITLE
Remove cat from the default pagers

### DIFF
--- a/pkg/pager/pager.go
+++ b/pkg/pager/pager.go
@@ -100,9 +100,5 @@ func lookupPager(c *cli.Context, defaultPager string) (string, error) {
 		return pager, nil
 	}
 
-	if pager, err := exec.LookPath(string(Cat)); err == nil {
-		return pager, nil
-	}
-
 	return "", errors.New("no pager available. Set $PAGER env variable or install 'less', 'more' or 'cat'")
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Removes cat from the default fall-back pagers.
Will default immediately to stdout instead of cat

## Why?
<!-- Tell your future self why have you made these changes -->
cat behaves the same as stdout so there is no need in it

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
