### PR TITLE
Allow ignoring print options flags to enforce custom behavior

### DIFF
--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -42,17 +42,18 @@ const (
 )
 
 type PrintOptions struct {
-	Fields     []string
-	FieldsLong []string
-	NoHeader   bool
-	Separator  string
-	All        bool
-	Pager      io.Writer
+	Fields      []string
+	FieldsLong  []string
+	IgnoreFlags bool
+	Output      OutputOption
+	Pager       io.Writer
+	NoPager     bool
+	NoHeader    bool
+	Separator   string
 }
 
 func PrintItems(c *cli.Context, items []interface{}, opts *PrintOptions) {
 	outputFlag := c.String(FlagOutput)
-	output := OutputOption(outputFlag)
 	columns := c.String(FlagColumns)
 
 	if opts.Pager == nil {
@@ -61,7 +62,7 @@ func PrintItems(c *cli.Context, items []interface{}, opts *PrintOptions) {
 		defer close()
 	}
 
-	if c.IsSet(FlagColumns) {
+	if !opts.IgnoreFlags && c.IsSet(FlagColumns) {
 		if columns == ColumnsLong {
 			opts.Fields = append(opts.Fields, opts.FieldsLong...)
 			opts.FieldsLong = []string{}
@@ -73,6 +74,11 @@ func PrintItems(c *cli.Context, items []interface{}, opts *PrintOptions) {
 			opts.Fields = cols
 			opts.FieldsLong = []string{}
 		}
+	}
+
+	output := opts.Output
+	if !opts.IgnoreFlags && c.IsSet(FlagOutput) {
+		output = OutputOption(outputFlag)
 	}
 
 	switch output {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Allows to solidify the behavior of `output.PrintItems` and `output.Pager`.
Useful especially when there are two or more Print/Pager statements in single command. That way the flags such as `--output json` or `--columns long` will be applied only to the ones that don't `IgnoreFlags`
 
``` go
opts := &output.PrintOptions{
	Fields:        []string{"Execution", "StartTime"},
	Output:        output.Card,
	IgnoreFlags:   true,
}
output.PrintItems(ctx, items, opts)
```

## Why?
<!-- Tell your future self why have you made these changes -->
Allows to use several Print/Pager statements in single command and control which one flags are actually applied to

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
