### PR TITLE
Set default output mode to Table

### DIFF
--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -76,9 +76,11 @@ func PrintItems(c *cli.Context, items []interface{}, opts *PrintOptions) {
 		}
 	}
 
-	output := opts.Output
+	output := Table
 	if !opts.IgnoreFlags && c.IsSet(FlagOutput) {
 		output = OutputOption(outputFlag)
+	} else if opts.Output != "" {
+		output = opts.Output
 	}
 
 	switch output {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Fixes the default output mode to Table

## Why?
<!-- Tell your future self why have you made these changes -->
Didn't print anything unless `--output` or PrintOptions.Output is passed

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
