### PR TITLE
Clear out direct DB connection for namespace commands

### DIFF
--- a/cli/namespace.go
+++ b/cli/namespace.go
@@ -74,7 +74,7 @@ func newNamespaceCommands() []*cli.Command {
 			Usage:   "Register workflow namespace",
 			Flags:   registerNamespaceFlags,
 			Action: func(c *cli.Context) error {
-				newNamespaceCLI(c, false).RegisterNamespace(c)
+				RegisterNamespace(c)
 				return nil
 			},
 		},
@@ -84,7 +84,7 @@ func newNamespaceCommands() []*cli.Command {
 			Usage:   "Update existing workflow namespace",
 			Flags:   updateNamespaceFlags,
 			Action: func(c *cli.Context) error {
-				newNamespaceCLI(c, false).UpdateNamespace(c)
+				UpdateNamespace(c)
 				return nil
 			},
 		},
@@ -94,7 +94,7 @@ func newNamespaceCommands() []*cli.Command {
 			Usage:   "Describe existing workflow namespace",
 			Flags:   describeNamespaceFlags,
 			Action: func(c *cli.Context) error {
-				newNamespaceCLI(c, false).DescribeNamespace(c)
+				DescribeNamespace(c)
 				return nil
 			},
 		},
@@ -104,7 +104,7 @@ func newNamespaceCommands() []*cli.Command {
 			Usage:   "List all namespaces",
 			Flags:   listNamespacesFlags,
 			Action: func(c *cli.Context) error {
-				newNamespaceCLI(c, false).ListNamespaces(c)
+				ListNamespaces(c)
 				return nil
 			},
 		},


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Removes direct DB operation for namespace commands

## Why?
<!-- Tell your future self why have you made these changes -->
- Recent discussions to deprecate direct DB operation for all of the commands. Maybe expose some operations through Admin API
- this design of namespace commands is inconsistent with the rest of tctl. Admin commands only live in `admin` root command 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
