### PR TITLE
Don't print nil error

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -142,6 +142,10 @@ func stopPlugins(ctx *cli.Context) error {
 }
 
 func handleError(c *cli.Context, err error) {
+	if err == nil {
+		return
+	}
+
 	fmt.Fprintf(os.Stderr, "%s %+v\n", color.Red(c, "Error:"), err)
 	if os.Getenv(showErrorStackEnv) != `` {
 		fmt.Fprintln(os.Stderr, color.Magenta(c, "Stack trace:"))


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Stopped printing nil error

## Why?
<!-- Tell your future self why have you made these changes -->
ExitErrHandler is executed even if error is nil. This resulted in printing nil error

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
