### PR TITLE
Make --no-pager print all pages, not just one

### DIFF
--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -96,7 +96,6 @@ func PrintItems(c *cli.Context, items []interface{}, opts *PrintOptions) {
 
 // Pager creates an interactive CLI mode to control the printing of items
 func Pager(c *cli.Context, iter collection.Iterator, opts *PrintOptions) error {
-	noPager := c.Bool(pager.FlagNoPager)
 	pageSize := c.Int(pager.FlagPageSize)
 
 	pager, close := newPagerWithDefault(c)
@@ -120,9 +119,6 @@ func Pager(c *cli.Context, iter collection.Iterator, opts *PrintOptions) error {
 			PrintItems(c, pageItems, opts)
 			pageItems = pageItems[:0]
 			opts.NoHeader = true
-			if noPager {
-				break
-			}
 		}
 	}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Changed --no-pager to print all of the pages instead of just one

## Why?
<!-- Tell your future self why have you made these changes -->
makes --no-pager responsible for a single thing - printing into stdout. It shouldn't change the behavior of how many pages are printed

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
ran locally on large # of items, verified all of the items are printed
`./tctl workflow list --no-pager`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
no