### PR TITLE
Support limiting number of items to print 

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -46,7 +46,11 @@ var FlagsForPagination = []cli.Flag{
 		Usage:   "disable interactive pager",
 	},
 	&cli.IntFlag{
-		Name:  pager.FlagPageSize,
+		Name:  output.FlagPages,
+		Usage: "number of pages to print",
+	},
+	&cli.IntFlag{
+		Name:  output.FlagPageSize,
 		Value: pager.DefaultListPageSize,
 		Usage: "items per page",
 	},

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -35,6 +35,10 @@ import (
 )
 
 var FlagsForPagination = []cli.Flag{
+	&cli.IntFlag{
+		Name:  output.FlagLimit,
+		Usage: "number of items to print",
+	},
 	&cli.StringFlag{
 		Name:    pager.FlagPager,
 		Usage:   "pager to use: less, cat, favoritePager..",
@@ -44,15 +48,6 @@ var FlagsForPagination = []cli.Flag{
 		Name:    pager.FlagNoPager,
 		Aliases: []string{"P"},
 		Usage:   "disable interactive pager",
-	},
-	&cli.IntFlag{
-		Name:  output.FlagPages,
-		Usage: "number of pages to print",
-	},
-	&cli.IntFlag{
-		Name:  output.FlagPageSize,
-		Value: pager.DefaultListPageSize,
-		Usage: "items per page",
 	},
 }
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -41,7 +41,7 @@ var FlagsForPagination = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:    pager.FlagPager,
-		Usage:   "pager to use: less, cat, favoritePager..",
+		Usage:   "pager to use: less, more, favoritePager..",
 		EnvVars: []string{"PAGER"},
 	},
 	&cli.BoolFlag{

--- a/pkg/output/flag.go
+++ b/pkg/output/flag.go
@@ -27,10 +27,9 @@ package output
 import "fmt"
 
 const (
-	FlagOutput   = "output"
-	FlagColumns  = "columns"
-	FlagPageSize = "page-size"
-	FlagPages    = "pages"
+	FlagOutput  = "output"
+	FlagColumns = "columns"
+	FlagLimit   = "limit"
 
 	ColumnsLong = "long"
 )

--- a/pkg/output/flag.go
+++ b/pkg/output/flag.go
@@ -27,8 +27,10 @@ package output
 import "fmt"
 
 const (
-	FlagOutput  = "output"
-	FlagColumns = "columns"
+	FlagOutput   = "output"
+	FlagColumns  = "columns"
+	FlagPageSize = "page-size"
+	FlagPages    = "pages"
 
 	ColumnsLong = "long"
 )

--- a/pkg/pager/flag.go
+++ b/pkg/pager/flag.go
@@ -25,9 +25,8 @@
 package pager
 
 const (
-	FlagPager    = "pager"
-	FlagNoPager  = "no-pager"
-	FlagPageSize = "pagesize"
+	FlagPager   = "pager"
+	FlagNoPager = "no-pager"
 )
 
 type PagerOption string


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

```bash 
./tctl w l --limit 5
    WorkflowId                    RunId                   StartTime    
  bee6469d___5  1a24aad1-da95-4ad2-899c-708fd538fb47  11 hours ago  
  bee6469d___4  bb980f5d-1359-4e39-9802-eb61914b38ee  11 hours ago  
  bee6469d___3  07688132-7d67-4171-937e-e0e4c51f1360  11 hours ago  
  bee6469d___2  26bbadc8-a010-4465-b489-3617d5409541  11 hours ago  
  bee6469d___1  493ddd84-bc4d-4d63-8c65-167e9a8fd2ea  11 hours ago
```

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds a flag `--limit` to limit the number of items to print
Removes the flag `--pagesize`

## Why?
<!-- Tell your future self why have you made these changes -->
Gives option to print limited number of items

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
locally 
`./tctl w l --limit 10`
expected: prints 10 items

`./tctl w l --limit 0`
expected: prints 0 items (disables output, useful for commands such as `workflow run` )


3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
yes