### PR TITLE
Add config feature to old tctl

### DIFF
--- a/cli_curr/config.go
+++ b/cli_curr/config.go
@@ -1,0 +1,115 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cli_curr
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli"
+
+	"github.com/temporalio/tctl/pkg/config"
+)
+
+func newConfigCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:  "get",
+			Usage: "get property",
+			Flags: []cli.Flag{},
+			Action: func(c *cli.Context) error {
+				return GetValue(c)
+			},
+		},
+		{
+			Name:  "set",
+			Usage: "set property",
+			Flags: []cli.Flag{},
+			Action: func(c *cli.Context) error {
+				return SetValue(c)
+			},
+		},
+	}
+}
+
+var (
+	validKeys = []string{
+		"version",
+	}
+)
+
+func GetValue(c *cli.Context) error {
+	if c.NArg() != 1 {
+		return errors.New("invalid number of args, expected 1: property name")
+	}
+
+	key := c.Args().Get(0)
+
+	if err := validateKey(key); err != nil {
+		return fmt.Errorf("unable to get property %v. %s", key, err)
+	}
+
+	val, err := config.Get(key)
+	if err != nil {
+		return fmt.Errorf("unable to get property %v. %s", key, err)
+	}
+	fmt.Printf("%v: %v\n", key, val)
+	return nil
+}
+
+func SetValue(c *cli.Context) error {
+	if c.NArg() != 2 {
+		return errors.New("invalid number of args, expected 2: property and value")
+	}
+
+	key := c.Args().Get(0)
+	val := c.Args().Get(1)
+
+	if err := validateKey(key); err != nil {
+		return fmt.Errorf("unable to set property %v. %s", key, err)
+	}
+
+	if err := config.Set(key, val); err != nil {
+		return fmt.Errorf("unable to set property %v. %s", key, err)
+	}
+
+	fmt.Printf("%v: %v\n", key, val)
+	return nil
+}
+
+func validateKey(key string) error {
+	// in composite keys such as alias.mycommand, the first part before dot is configuration property name
+	// second part is custom value
+	key = strings.Split(key, ".")[0]
+
+	for _, k := range validKeys {
+		if strings.Compare(key, k) == 0 {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unknown key %v", key)
+}

--- a/cli_curr/main.go
+++ b/cli_curr/main.go
@@ -33,5 +33,13 @@ import (
 // NewCliApp instantiates a new instance of the CLI application.
 func NewCliApp() *cli.App {
 	app := tctlCurrent.NewCliApp()
+	app.Commands = append(app.Commands,
+		cli.Command{
+			Name:        "config",
+			Aliases:     []string{"c"},
+			Usage:       "Configure tctl",
+			Subcommands: newConfigCommands(),
+		})
+
 	return app
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,8 +28,8 @@ import (
 	"os"
 
 	"github.com/temporalio/tctl/cli"
-	"github.com/temporalio/tctl/pkg/config"
 	"github.com/temporalio/tctl/cli_curr"
+	"github.com/temporalio/tctl/pkg/config"
 )
 
 // Start using this CLI tool with command


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adds config feature to tctl

```bash
./tctl config set version next
```

![image](https://user-images.githubusercontent.com/11838981/127720002-93104240-e1b3-4660-87e4-d185872830a9.png)


<!-- Tell your future self why have you made these changes -->
**Why?**
Will allow to switch to experimental `next` version of tctl UX by running

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```bash
./tctl config set version next
```
and checking config file

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no risks

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no