### PR TITLE
Rename --format-time to --time-format

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -59,7 +59,7 @@ var FlagsForRendering = []cli.Flag{
 		Value:   string(output.Table),
 	},
 	&cli.StringFlag{
-		Name:  format.FlagFormatTime,
+		Name:  format.FlagTimeFormat,
 		Usage: fmt.Sprintf("format time as: %v, %v, %v.", format.Relative, format.ISO, format.Raw),
 		Value: string(format.Relative),
 	},

--- a/pkg/format/time.go
+++ b/pkg/format/time.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	FlagFormatTime = "format-time"
+	FlagTimeFormat = "time-format"
 )
 
 type FormatTimeOption string
@@ -47,7 +47,7 @@ const (
 )
 
 func FormatTime(c *cli.Context, val time.Time) string {
-	formatFlag := c.String(FlagFormatTime)
+	formatFlag := c.String(FlagTimeFormat)
 
 	timeVal := timestamp.TimeValue(&val)
 	format := FormatTimeOption(formatFlag)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Renamed flag `--format-time` to `--time-format`

## Why?
<!-- Tell your future self why have you made these changes -->
As per recent comment and proposal update https://github.com/temporalio/proposals/pull/35#pullrequestreview-730151615

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
```bash
./tctl config set version next
./tctl w l --time-format iso
       WorkflowId                       RunId                       StartTime        
  19547e_TimedOut        f08dd420-a736-4d1f-a424-9fd89034a2cd  2021-08-15T22:18:25Z  
  19547e_ContinuedAsNew  a504de26-b0b7-45f8-b5bf-f15c6abafab1  2021-08-15T22:18:25Z  
  9d1d5b_Running         37df046c-9cfb-406f-829f-33a3e90cd857  2021-08-11T22:42:20Z
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
yes