### PR TITLE
Reuse workflow history helper between commands

### DIFF
--- a/cli/namespaceCommands.go
+++ b/cli/namespaceCommands.go
@@ -25,7 +25,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- reused workflow history printer for `workflow show` command

## Why?
<!-- Tell your future self why have you made these changes -->

- updating in accordance to changes in `temporal` repo
- reusing code between `workflow observe`, `show` and `run` commands

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

ran the commands. Unit tests tbu

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
