### PR TITLE
Fix --global-namespace flag name in tests

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -118,25 +118,25 @@ func (s *cliAppSuite) TestAppCommands() {
 
 func (s *cliAppSuite) TestNamespaceRegister_LocalNamespace() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
-	errorCode := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global_namespace", "false"})
+	errorCode := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "false"})
 	s.Equal(0, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_GlobalNamespace() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
-	errorCode := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global_namespace", "true"})
+	errorCode := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "true"})
 	s.Equal(0, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_NamespaceExist() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceAlreadyExists(""))
-	errorCode := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global_namespace", "true"})
+	errorCode := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "true"})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_Failed() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global_namespace", "true"})
+	errorCode := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "true"})
 	s.Equal(1, errorCode)
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Renamed the flag name `--global_namespace` -> `--global-namespace`

## Why?
<!-- Tell your future self why have you made these changes -->

Fixes the name

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- validated that unit tests don't complain about the flag name 
- additionally verified that there are no more flags with underscores in the tests using a regex

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
