### PR TITLE
Rework commands aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ get started:
 `./tctl` for help on top level commands and global options   
 `./tctl namespace` for help on namespace operations  
 `./tctl workflow` for help on workflow operations  
-`./tctl taskqueue` for help on tasklist operations  
+`./tctl task-queue` for help on tasklist operations  
 (`./tctl help`, `./tctl help [namespace|workflow]` will also print help messages)
 
 **Note:** Make sure you have a Temporal server running before using the CLI.

--- a/cli/activity.go
+++ b/cli/activity.go
@@ -31,9 +31,8 @@ import (
 func newActivityCommands() []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:    "complete",
-			Aliases: []string{"comp"},
-			Usage:   "complete an activity",
+			Name:  "complete",
+			Usage: "complete an activity",
 			Flags: append(flagsForExecution, []cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagActivityID,

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -80,7 +80,7 @@ func (m *clientFactoryMock) HealthClient(_ *cli.Context) healthpb.HealthClient {
 var commands = []string{
 	"namespace", "n",
 	"workflow", "w",
-	"taskqueue", "tq",
+	"task-queue", "tq",
 }
 
 var cliTestNamespace = "cli-test-namespace"
@@ -462,14 +462,14 @@ var describeTaskQueueResponse = &workflowservice.DescribeTaskQueueResponse{
 
 func (s *cliAppSuite) TestDescribeTaskQueue() {
 	s.sdkClient.On("DescribeTaskQueue", mock.Anything, mock.Anything, mock.Anything).Return(describeTaskQueueResponse, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "taskqueue", "describe", "--task-queue", "test-taskQueue"})
+	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "task-queue", "describe", "--task-queue", "test-taskQueue"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestDescribeTaskQueue_Activity() {
 	s.sdkClient.On("DescribeTaskQueue", mock.Anything, mock.Anything, mock.Anything).Return(describeTaskQueueResponse, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "taskqueue", "describe", "--task-queue", "test-taskQueue", "--task-queue-type", "activity"})
+	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "task-queue", "describe", "--task-queue", "test-taskQueue", "--task-queue-type", "activity"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -40,9 +40,8 @@ func newClusterCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:    "list-search-attributes",
-			Usage:   "List search attributes that can be used in list workflow query",
-			Aliases: []string{"gsa"},
+			Name:  "list-search-attributes",
+			Usage: "List search attributes that can be used in list workflow query",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:    output.FlagOutput,

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -19,12 +19,12 @@ var tctlCommands = []*cli.Command{
 	},
 	{
 		Name:        "activity",
-		Aliases:     []string{"act"},
+		Aliases:     []string{"a"},
 		Usage:       "operate activities of workflow",
 		Subcommands: newActivityCommands(),
 	},
 	{
-		Name:        "taskqueue",
+		Name:        "task-queue",
 		Aliases:     []string{"tq"},
 		Usage:       "Operate Temporal task queue",
 		Subcommands: newTaskQueueCommands(),
@@ -36,12 +36,11 @@ var tctlCommands = []*cli.Command{
 	},
 	{
 		Name:        "cluster",
-		Aliases:     []string{"cl"},
 		Usage:       "Operate Temporal cluster",
 		Subcommands: newClusterCommands(),
 	},
 	{
-		Name:        "dataconverter",
+		Name:        "data-converter",
 		Aliases:     []string{"dc"},
 		Usage:       "Operate Custom Data Converter",
 		Subcommands: newDataConverterCommands(),

--- a/cli/namespace.go
+++ b/cli/namespace.go
@@ -69,26 +69,24 @@ func parseNamespaceDataKVs(namespaceDataStr string) (map[string]string, error) {
 func newNamespaceCommands() []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:    "register",
-			Aliases: []string{"re"},
-			Usage:   "Register workflow namespace",
-			Flags:   registerNamespaceFlags,
+			Name:  "register",
+			Usage: "Register workflow namespace",
+			Flags: registerNamespaceFlags,
 			Action: func(c *cli.Context) error {
 				return RegisterNamespace(c)
 			},
 		},
 		{
-			Name:    "update",
-			Aliases: []string{"up", "u"},
-			Usage:   "Update existing workflow namespace",
-			Flags:   updateNamespaceFlags,
+			Name:  "update",
+			Usage: "Update existing workflow namespace",
+			Flags: updateNamespaceFlags,
 			Action: func(c *cli.Context) error {
 				return UpdateNamespace(c)
 			},
 		},
 		{
 			Name:    "describe",
-			Aliases: []string{"desc"},
+			Aliases: []string{"d"},
 			Usage:   "Describe existing workflow namespace",
 			Flags:   describeNamespaceFlags,
 			Action: func(c *cli.Context) error {

--- a/cli/taskQueue.go
+++ b/cli/taskQueue.go
@@ -34,7 +34,7 @@ func newTaskQueueCommands() []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:    "describe",
-			Aliases: []string{"desc"},
+			Aliases: []string{"d"},
 			Usage:   "Describe pollers info of task queue",
 			Flags: append([]cli.Flag{
 				&cli.StringFlag{

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -43,7 +43,7 @@ func newWorkflowCommands() []*cli.Command {
 		},
 		{
 			Name:    "describe",
-			Aliases: []string{"desc"},
+			Aliases: []string{"d"},
 			Usage:   "show information of workflow execution",
 			Flags: append(flagsForExecution, []cli.Flag{
 				&cli.BoolFlag{
@@ -83,7 +83,7 @@ func newWorkflowCommands() []*cli.Command {
 		},
 		{
 			Name:    "observe",
-			Aliases: []string{"ob"},
+			Aliases: []string{"o"},
 			Usage:   "show the progress of workflow history",
 			Flags:   append(append(flagsForExecution, flagsForShowWorkflow...), flags.FlagsForPaginationAndRendering...),
 			Action: func(c *cli.Context) error {
@@ -148,27 +148,24 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:    "count",
-			Aliases: []string{"cnt"},
-			Usage:   "count number of workflow executions (need to enable Temporal server on ElasticSearch)",
-			Flags:   getFlagsForCount(),
+			Name:  "count",
+			Usage: "count number of workflow executions (need to enable Temporal server on ElasticSearch)",
+			Flags: getFlagsForCount(),
 			Action: func(c *cli.Context) error {
 				return CountWorkflow(c)
 			},
 		},
 		{
-			Name:    "cancel",
-			Aliases: []string{"c"},
-			Usage:   "cancel a workflow execution",
-			Flags:   flagsForExecution,
+			Name:  "cancel",
+			Usage: "cancel a workflow execution",
+			Flags: flagsForExecution,
 			Action: func(c *cli.Context) error {
 				return CancelWorkflow(c)
 			},
 		},
 		{
-			Name:    "terminate",
-			Aliases: []string{"term"},
-			Usage:   "terminate a new workflow execution",
+			Name:  "terminate",
+			Usage: "terminate a new workflow execution",
 			Flags: append(flagsForExecution, []cli.Flag{
 				&cli.StringFlag{
 					Name:    FlagReason,
@@ -181,9 +178,8 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:    "reset",
-			Aliases: []string{"rs"},
-			Usage:   "reset the workflow, by either eventId or resetType.",
+			Name:  "reset",
+			Usage: "reset the workflow, by either eventId or resetType.",
 			Flags: append(flagsForExecution, []cli.Flag{
 				&cli.StringFlag{
 					Name:  FlagEventID,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

* Removed aliases of the commands that perform write operations
  * if users really want aliases for such opeartions, they can still do this by explicly configuring aliases using `alias` command  
* shortened the aliases of some commands

## Why?
<!-- Tell your future self why have you made these changes -->

* would prefer users to explicitly type the names of commands that perform write operation. Users can still manually set up aliases for such commands

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
