### PR TITLE
Remove temporal dependencies from CLI framework level pkgs

### DIFF
--- a/pkg/iterator/iterator.go
+++ b/pkg/iterator/iterator.go
@@ -22,48 +22,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package format
+package iterator
 
-import (
-	"fmt"
-	"time"
-
-	"github.com/dustin/go-humanize"
-	"github.com/urfave/cli/v2"
-)
-
-const (
-	FlagTimeFormat = "time-format"
-)
-
-type FormatTimeOption string
-
-const (
-	Relative FormatTimeOption = "relative"
-	ISO      FormatTimeOption = "iso"
-	Raw      FormatTimeOption = "raw"
-)
-
-func FormatTime(c *cli.Context, val time.Time) string {
-	formatFlag := c.String(FlagTimeFormat)
-
-	timeVal := TimeValue(&val)
-	format := FormatTimeOption(formatFlag)
-	switch format {
-	case ISO:
-		return timeVal.Format(time.RFC3339)
-	case Raw:
-		return fmt.Sprintf("%v", timeVal)
-	case Relative:
-		return humanize.Time(timeVal)
-	default:
-		return humanize.Time(timeVal)
+type (
+	// Iterator represents the interface for iterator
+	Iterator interface {
+		// HasNext return whether this iterator has next value
+		HasNext() bool
+		// Next returns the next item and error
+		Next() (interface{}, error)
 	}
-}
-
-func TimeValue(t *time.Time) time.Time {
-	if t == nil {
-		return time.Time{}
-	}
-	return *t
-}
+)

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -25,13 +25,14 @@
 package output
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
+	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/hokaccha/go-prettyjson"
 	"github.com/urfave/cli/v2"
-	"go.temporal.io/server/common/codec"
 
 	"github.com/temporalio/tctl/pkg/color"
 )
@@ -62,13 +63,14 @@ func ParseToJSON(c *cli.Context, o interface{}, indent bool) (string, error) {
 		b, err = encoder.Marshal(o)
 	} else {
 		if pb, ok := o.(proto.Message); ok {
-			var encoder *codec.JSONPBEncoder
+			encoder := jsonpb.Marshaler{}
 			if indent {
-				encoder = codec.NewJSONPBIndentEncoder("  ")
-			} else {
-				encoder = codec.NewJSONPBEncoder()
+				encoder.Indent = "  "
 			}
-			b, err = encoder.Encode(pb)
+
+			var buf bytes.Buffer
+			err = encoder.Marshal(&buf, pb)
+			b = buf.Bytes()
 		} else {
 			if indent {
 				b, err = json.MarshalIndent(o, "", "  ")

--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -32,9 +32,9 @@ import (
 	"time"
 
 	"github.com/temporalio/tctl/pkg/format"
+	"github.com/temporalio/tctl/pkg/iterator"
 	"github.com/temporalio/tctl/pkg/pager"
 	"github.com/urfave/cli/v2"
-	"go.temporal.io/server/common/collection"
 )
 
 const (
@@ -95,7 +95,7 @@ func PrintItems(c *cli.Context, items []interface{}, opts *PrintOptions) {
 }
 
 // Pager creates an interactive CLI mode to control the printing of items
-func Pager(c *cli.Context, iter collection.Iterator, opts *PrintOptions) error {
+func Pager(c *cli.Context, iter iterator.Iterator, opts *PrintOptions) error {
 	limit := c.Int(FlagLimit)
 
 	pager, close := newPagerWithDefault(c)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Removed `go.temporal.io` dependency from tctl's `pkg` module 

## Why?
<!-- Tell your future self why have you made these changes -->

I want to use the CLI level tools to improve UX of tctl admins commands. These commands are implemented in temporal repo and are dependent on internal packages.

These CLI framework tools are implemented as `/pkg` module and provides
 - CLI paginations 
 - output formatting (table/json/card)
 -  time formatting (relative/iso..) 
 - coloring
 - generic config feature 
 - printing progress bar/time for long processes
 - etc..

In order to be able to use these CLI framework tools in admin command, this requires to separate the tctl into two repos:
- cli framework tools (aka currently `/pkg` module in code`) - see details below
- tctl commands and implementation

The current PRs removes temporal dependencies from `/pkg`, so that i can separate this package into its own repo 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
