### PR TITLE
Add authorization plugin build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Executables
 /tctl
+/tctl-authorization-plugin
 /bin
 
 # Goreleaser

--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,8 @@
 The MIT License
 
-Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+Copyright (c) 2021 Temporal Technologies Inc.  All rights reserved.
 
 Copyright (c) 2020 Uber Technologies, Inc.
-
-Copyright (c) 2019 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,12 @@ COLOR := "\e[1;36m%s\e[0m\n"
 build:
 	@printf $(COLOR) "Build tctl with OS: $(GOOS), ARCH: $(GOARCH)..."
 	CGO_ENABLED=0 go build -o tctl cmd/main.go
+	@printf $(COLOR) "Build tctl-authorization-plugin with OS: $(GOOS), ARCH: $(GOARCH)..."
+	CGO_ENABLED=$(CGO_ENABLED) go build -o tctl-authorization-plugin cmd/plugins/authorization/main.go
 
 clean:
 	@printf $(COLOR) "Clearing binaries..."
-	@rm -f tctl
+	@rm -f tctl tctl-authorization-plugin
 
 ##### Test #####
 TEST_TIMEOUT := 20m


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Starts building authorization plugin with `make build`

- Removed github license notion since entirely rewrote the `config` feature in older PR (and in the old config feature it was just few lines looked up in github's cli)

## Why?
<!-- Tell your future self why have you made these changes -->

Makes authorization plugin available by default with the build

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

`make build`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
