### PR TITLE
Shorten docker image SHA tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           images: temporaliotest/tctl
           tags: |
-            type=sha,format=long,event=branch
+            type=sha,format=short,event=branch
             type=semver,pattern={{version}}
 
       - name: Set up QEMU


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Changes per-commit docker images to be tagged by shortened SHA instead of full

Before:
`docker pull temporalio/tctl:sha-aa17a4aba898a43d2bd74c94088b69348bc275d1`

After:
`docker pull temporalio/tctl:sha-5502441`

## Why?
<!-- Tell your future self why have you made these changes -->

looks cleaner

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
