### PR TITLE
Use the custom data converter for query responses.

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -43,6 +43,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
 
 	"github.com/temporalio/tctl/cli/dataconverter"
 	"github.com/temporalio/tctl/cli/stringify"
@@ -54,7 +55,7 @@ import (
 // HistoryEventToString convert HistoryEvent to string
 func HistoryEventToString(e *historypb.HistoryEvent, printFully bool, maxFieldLength int) string {
 	data := getEventAttributes(e)
-	return stringify.AnyToString(data, printFully, maxFieldLength, dataconverter.GetCurrent())
+	return stringify.AnyToString(data, printFully, maxFieldLength, customDataConverter())
 }
 
 // ColorEvent takes an event and return string with color
@@ -671,4 +672,12 @@ func prompt(msg string, autoConfirm bool) {
 	if textLower != "y" && textLower != "yes" {
 		os.Exit(0)
 	}
+}
+
+func defaultDataConverter() converter.DataConverter {
+	return converter.GetDefaultDataConverter()
+}
+
+func customDataConverter() converter.DataConverter {
+	return dataconverter.GetCurrent()
 }

--- a/cli/workflowCommands.go
+++ b/cli/workflowCommands.go
@@ -52,13 +52,13 @@ import (
 
 	"github.com/temporalio/tctl-core/pkg/color"
 	"github.com/temporalio/tctl-core/pkg/output"
+	"github.com/temporalio/tctl/cli/stringify"
 	clispb "go.temporal.io/server/api/cli/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/convert"
-	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service/history/workflow"
@@ -516,7 +516,7 @@ func queryWorkflowHelper(c *cli.Context, queryType string) error {
 	if queryResponse.QueryRejected != nil {
 		fmt.Printf("Query was rejected, workflow has status: %v\n", queryResponse.QueryRejected.GetStatus())
 	} else {
-		queryResult := payloads.ToString(queryResponse.QueryResult)
+		queryResult := stringify.AnyToString(queryResponse.QueryResult, true, 0, customDataConverter())
 		fmt.Printf("Query result:\n%v\n", queryResult)
 	}
 
@@ -814,7 +814,7 @@ func convertDescribeWorkflowExecutionResponse(c *cli.Context, resp *workflowserv
 		}
 
 		if pendingActivity.GetHeartbeatDetails() != nil {
-			pendingActivityStr.HeartbeatDetails = payloads.ToString(pendingActivity.GetHeartbeatDetails())
+			pendingActivityStr.HeartbeatDetails = stringify.AnyToString(pendingActivity.GetHeartbeatDetails(), true, 0, customDataConverter())
 		}
 		pendingActivitiesStr = append(pendingActivitiesStr, pendingActivityStr)
 	}
@@ -867,7 +867,7 @@ func printRunStatus(c *cli.Context, event *historypb.HistoryEvent) {
 	switch event.GetEventType() {
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
 		fmt.Printf("  Status: %s\n", color.Green(c, "COMPLETED"))
-		result := payloads.ToString(event.GetWorkflowExecutionCompletedEventAttributes().GetResult())
+		result := stringify.AnyToString(event.GetWorkflowExecutionCompletedEventAttributes().GetResult(), true, 0, customDataConverter())
 		fmt.Printf("  Output: %s\n", result)
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
 		fmt.Printf("  Status: %s\n", color.Red(c, "FAILED"))
@@ -877,7 +877,7 @@ func printRunStatus(c *cli.Context, event *historypb.HistoryEvent) {
 		fmt.Printf("  Retry status: %s\n", event.GetWorkflowExecutionTimedOutEventAttributes().GetRetryState())
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
 		fmt.Printf("  Status: %s\n", color.Red(c, "CANCELED"))
-		details := payloads.ToString(event.GetWorkflowExecutionCanceledEventAttributes().GetDetails())
+		details := stringify.AnyToString(event.GetWorkflowExecutionCanceledEventAttributes().GetDetails(), true, 0, customDataConverter())
 		fmt.Printf("  Detail: %s\n", details)
 	}
 }

--- a/cli_curr/data_converter_commands.go
+++ b/cli_curr/data_converter_commands.go
@@ -35,7 +35,6 @@ import (
 	"github.com/urfave/cli"
 
 	commonpb "go.temporal.io/api/common/v1"
-	"go.temporal.io/server/tools/cli/dataconverter"
 )
 
 const dataConverterURL = "%s/data-converter/%d"
@@ -70,7 +69,7 @@ func processMessage(c *websocket.Conn) error {
 
 	payloadResponse := PayloadResponse{
 		RequestID: payloadRequest.RequestID,
-		Content:   dataconverter.GetCurrent().ToString(&payload),
+		Content:   customDataConverter().ToString(&payload),
 	}
 
 	var response []byte

--- a/cli_curr/util.go
+++ b/cli_curr/util.go
@@ -45,6 +45,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
 
 	"go.temporal.io/server/common/codec"
 	"go.temporal.io/server/common/collection"
@@ -75,7 +76,7 @@ func GetHistory(ctx context.Context, workflowClient sdkclient.Client, workflowID
 // HistoryEventToString convert HistoryEvent to string
 func HistoryEventToString(e *historypb.HistoryEvent, printFully bool, maxFieldLength int) string {
 	data := getEventAttributes(e)
-	return stringify.AnyToString(data, printFully, maxFieldLength, dataconverter.GetCurrent())
+	return stringify.AnyToString(data, printFully, maxFieldLength, customDataConverter())
 }
 
 // ColorEvent takes an event and return string with color
@@ -811,4 +812,12 @@ func prompt(msg string, autoConfirm bool) {
 	if textLower != "y" && textLower != "yes" {
 		os.Exit(1)
 	}
+}
+
+func defaultDataConverter() converter.DataConverter {
+	return converter.GetDefaultDataConverter()
+}
+
+func customDataConverter() converter.DataConverter {
+	return dataconverter.GetCurrent()
 }

--- a/cli_curr/workflowCommands.go
+++ b/cli_curr/workflowCommands.go
@@ -59,12 +59,9 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/codec"
 	"go.temporal.io/server/common/convert"
-	"go.temporal.io/server/common/payload"
-	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service/history/workflow"
-	"go.temporal.io/server/tools/cli/dataconverter"
 	"go.temporal.io/server/tools/cli/stringify"
 )
 
@@ -119,7 +116,7 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 				}
 				prevEvent = *e
 			}
-			fmt.Println(stringify.AnyToString(e, true, maxFieldLength, dataconverter.GetCurrent()))
+			fmt.Println(stringify.AnyToString(e, true, maxFieldLength, customDataConverter()))
 		}
 	} else if c.IsSet(FlagEventID) { // only dump that event
 		eventID := c.Int(FlagEventID)
@@ -127,7 +124,7 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 			ErrorAndExit("EventId out of range.", fmt.Errorf("number should be 1 - %d inclusive", len(history.Events)))
 		}
 		e := history.Events[eventID-1]
-		fmt.Println(stringify.AnyToString(e, true, 0, dataconverter.GetCurrent()))
+		fmt.Println(stringify.AnyToString(e, true, 0, customDataConverter()))
 	} else { // use table to pretty output, will trim long text
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetBorder(false)
@@ -384,7 +381,7 @@ func getPrintableMemo(memo *commonpb.Memo) string {
 	buf := new(bytes.Buffer)
 	for k, v := range memo.Fields {
 		var memo string
-		err := payload.Decode(v, &memo)
+		err := defaultDataConverter().FromPayload(v, &memo)
 		if err != nil {
 			memo = "Memo is not a string"
 		}
@@ -592,7 +589,7 @@ func queryWorkflowHelper(c *cli.Context, queryType string) {
 	if queryResponse.QueryRejected != nil {
 		fmt.Printf("Query was rejected, workflow has status: %v\n", queryResponse.QueryRejected.GetStatus())
 	} else {
-		queryResult := payloads.ToString(queryResponse.QueryResult)
+		queryResult := stringify.AnyToString(queryResponse.QueryResult, true, 0, customDataConverter())
 		fmt.Printf("Query result:\n%v\n", queryResult)
 	}
 }
@@ -952,7 +949,7 @@ func convertDescribeWorkflowExecutionResponse(resp *workflowservice.DescribeWork
 		}
 
 		if pendingActivity.GetHeartbeatDetails() != nil {
-			pendingActivityStr.HeartbeatDetails = payloads.ToString(pendingActivity.GetHeartbeatDetails())
+			pendingActivityStr.HeartbeatDetails = stringify.AnyToString(pendingActivity.GetHeartbeatDetails(), true, 0, customDataConverter())
 		}
 		pendingActivitiesStr = append(pendingActivitiesStr, pendingActivityStr)
 	}
@@ -1122,7 +1119,7 @@ func printRunStatus(event *historypb.HistoryEvent) {
 	switch event.GetEventType() {
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
 		fmt.Printf("  Status: %s\n", colorGreen("COMPLETED"))
-		result := payloads.ToString(event.GetWorkflowExecutionCompletedEventAttributes().GetResult())
+		result := stringify.AnyToString(event.GetWorkflowExecutionCompletedEventAttributes().GetResult(), true, 0, customDataConverter())
 		fmt.Printf("  Output: %s\n", result)
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
 		fmt.Printf("  Status: %s\n", colorRed("FAILED"))
@@ -1132,7 +1129,7 @@ func printRunStatus(event *historypb.HistoryEvent) {
 		fmt.Printf("  Retry status: %s\n", event.GetWorkflowExecutionTimedOutEventAttributes().GetRetryState())
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
 		fmt.Printf("  Status: %s\n", colorRed("CANCELED"))
-		details := payloads.ToString(event.GetWorkflowExecutionCanceledEventAttributes().GetDetails())
+		details := stringify.AnyToString(event.GetWorkflowExecutionCanceledEventAttributes().GetDetails(), true, 0, customDataConverter())
 		fmt.Printf("  Detail: %s\n", details)
 	}
 }
@@ -1396,9 +1393,9 @@ func printListResults(executions []*workflowpb.WorkflowExecutionInfo, inJSON boo
 			}
 		} else {
 			if more || i < len(executions)-1 {
-				fmt.Println(stringify.AnyToString(execution, true, 0, dataconverter.GetCurrent()) + ",")
+				fmt.Println(stringify.AnyToString(execution, true, 0, customDataConverter()) + ",")
 			} else {
-				fmt.Println(stringify.AnyToString(execution, true, 0, dataconverter.GetCurrent()))
+				fmt.Println(stringify.AnyToString(execution, true, 0, customDataConverter()))
 			}
 		}
 	}
@@ -1975,13 +1972,17 @@ func CompleteActivity(c *cli.Context) {
 	ctx, cancel := newContext(c)
 	defer cancel()
 
+	// TODO: This should use customDataConverter once the plugin interface
+	// supports the full DataConverter API.
+	resultPayloads, _ := defaultDataConverter().ToPayloads(result)
+
 	frontendClient := cFactory.FrontendClient(c)
 	_, err := frontendClient.RespondActivityTaskCompletedById(ctx, &workflowservice.RespondActivityTaskCompletedByIdRequest{
 		Namespace:  namespace,
 		WorkflowId: wid,
 		RunId:      rid,
 		ActivityId: activityID,
-		Result:     payloads.EncodeString(result),
+		Result:     resultPayloads,
 		Identity:   identity,
 	})
 	if err != nil {
@@ -2006,6 +2007,10 @@ func FailActivity(c *cli.Context) {
 	ctx, cancel := newContext(c)
 	defer cancel()
 
+	// TODO: This should use customDataConverter once the plugin interface
+	// supports the full DataConverter API.
+	detailsPayloads, _ := defaultDataConverter().ToPayloads(detail)
+
 	frontendClient := cFactory.FrontendClient(c)
 	_, err := frontendClient.RespondActivityTaskFailedById(ctx, &workflowservice.RespondActivityTaskFailedByIdRequest{
 		Namespace:  namespace,
@@ -2017,7 +2022,7 @@ func FailActivity(c *cli.Context) {
 			Source:  "CLI",
 			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
 				NonRetryable: true,
-				Details:      payloads.EncodeString(detail),
+				Details:      detailsPayloads,
 			}},
 		},
 		Identity: identity,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

tctl will now use the custom data converter for printing query results.

<!-- Tell your future self why have you made these changes -->
**Why?**

This lines up with the SDK behaviour on the worker side which uses the custom data converter to encode the query response.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Tested `tctl workflow stack` on a Temporal application using an encrypting data converter. Without this fix I see "[encoding binary/encrypted: payload encoding is not supported]". With this fix I see the query response as I'd expect.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No.
