### PR TITLE
Remove trailing slash in dc tool user input

### DIFF
--- a/cli/data_converter_commands.go
+++ b/cli/data_converter_commands.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gorilla/websocket"
 	"github.com/temporalio/tctl/cli/dataconverter"
@@ -129,7 +130,7 @@ func DataConverter(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to create listener: %s", err)
 	}
-	origin := c.String(FlagWebURL)
+	origin := strings.TrimSuffix(c.String(FlagWebURL), "/")
 	port := listener.Addr().(*net.TCPAddr).Port
 	url := fmt.Sprintf(dataConverterURL, origin, port)
 


### PR DESCRIPTION
Original PR in temporal server: https://github.com/temporalio/temporal/pull/2299

Moved here.

Original PR notes:
> Describe what has changed in this PR 

Removes any trailing slash that the user inputs to the dc cli command


> Tell your future self why have you made these changes 

It prevents this `https://<someURL>//data-converter/52352` and saves engineers the hours trying to figure out what went wrong.


> How have you verified this change? Tested locally? Added a unit test? Checked in staging env?

I built the tctl plugin and copied it to my path. I then verified that the URL was stripped of the slash. 


> Assuming the worst case, what can be broken when deploying this change to production?

tctl dc could be broken


> Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) 

no

