### PR TITLE
Create dedicated command to create aliases

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -51,4 +51,5 @@ var tctlCommands = []*cli.Command{
 		Usage:       "Configure tctl",
 		Subcommands: newConfigCommands(),
 	},
+	newAliasCommand(),
 }

--- a/cli/config.go
+++ b/cli/config.go
@@ -35,7 +35,6 @@ import (
 var (
 	rootKeys = []string{
 		config.KeyActive,
-		config.KeyAlias,
 		"version",
 	}
 	envKeys = []string{
@@ -49,7 +48,7 @@ func newConfigCommands() []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:  "get",
-			Usage: "get property",
+			Usage: "Print config values",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  config.KeyActive,
@@ -74,7 +73,7 @@ func newConfigCommands() []*cli.Command {
 		},
 		{
 			Name:  "set",
-			Usage: "set property",
+			Usage: "Set config values",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:  config.KeyActive,
@@ -154,6 +153,30 @@ func SetValue(c *cli.Context) error {
 	return nil
 }
 
+func newAliasCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "alias",
+		Usage: "Create an alias for command",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "command",
+				Usage:    "New command name",
+				Required: true,
+				Value:    "mycommand",
+			},
+			&cli.StringFlag{
+				Name:     "alias",
+				Usage:    "Alias for command",
+				Required: true,
+				Value:    "workflow list --output json",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			return createAlias(c)
+		},
+	}
+}
+
 func isRootKey(key string) bool {
 	for _, k := range rootKeys {
 		if strings.Compare(key, k) == 0 {
@@ -170,4 +193,24 @@ func isEnvKey(key string) bool {
 		}
 	}
 	return false
+}
+
+func createAlias(c *cli.Context) error {
+	command := c.String("command")
+	alias := c.String("alias")
+
+	fullKey := fmt.Sprintf("%s.%s", config.KeyAlias, command)
+
+	// aliases, error := tctlConfig.GetAliases()
+	// if error != nil {
+	// 	return error
+	// }
+	// aliases[command] = alias
+
+	if err := tctlConfig.Set(c, fullKey, alias); err != nil {
+		return fmt.Errorf("unable to set property %s: %s", config.KeyAlias, err)
+	}
+
+	fmt.Printf("%v: %v\n", color.Magenta(c, "%v", config.KeyAlias), alias)
+	return nil
 }

--- a/cli/config.go
+++ b/cli/config.go
@@ -201,12 +201,6 @@ func createAlias(c *cli.Context) error {
 
 	fullKey := fmt.Sprintf("%s.%s", config.KeyAlias, command)
 
-	// aliases, error := tctlConfig.GetAliases()
-	// if error != nil {
-	// 	return error
-	// }
-	// aliases[command] = alias
-
 	if err := tctlConfig.Set(c, fullKey, alias); err != nil {
 		return fmt.Errorf("unable to set property %s: %s", config.KeyAlias, err)
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds dedicated `alias` command to add aliases for custom commands

## Why?
<!-- Tell your future self why have you made these changes -->

simplifies usage and provides better help message than generic `tctl config set aliases.mycommand "workflwos list"`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

```
$ tctl alias --command wcard --alias "workflow list --output card"
aliases: workflow list --output card

$ tctl alias --command wjson --alias "workflow list --output json"
aliases: workflow list --output json

$ cat ~/.config/temporalio/tctl.yaml 
active: local
aliases:
    wcard: workflow list --output card
    wjson: workflow list --output json
environments:
  local:
    address: 127.0.0.1:7233
    namespace: default
version: next
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
