### PR TITLE
Remote data encoder support.

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 
 	"github.com/urfave/cli/v2"
+	"go.temporal.io/sdk/converter"
 
 	"github.com/temporalio/tctl-kit/pkg/color"
 	"github.com/temporalio/tctl/cli/dataconverter"
@@ -117,6 +118,12 @@ func NewCliApp() *cli.App {
 			EnvVars: []string{"TEMPORAL_CLI_PLUGIN_DATA_CONVERTER"},
 		},
 		&cli.StringFlag{
+			Name:    FlagRemoteDataConverterEndpoint,
+			Value:   "",
+			Usage:   "Remote data converter endpoint",
+			EnvVars: []string{"TEMPORAL_CLI_REMOTE_DATA_CONVERTER_ENDPOINT"},
+		},
+		&cli.StringFlag{
 			Name:  color.FlagColor,
 			Usage: fmt.Sprintf("when to use color: %v, %v, %v.", color.Auto, color.Always, color.Never),
 			Value: string(color.Auto),
@@ -145,6 +152,18 @@ func NewCliApp() *cli.App {
 }
 
 func loadPlugins(ctx *cli.Context) error {
+	dcRemote := ctx.String(FlagRemoteDataConverterEndpoint)
+	if dcRemote != "" {
+		dataconverter.SetCurrent(
+			converter.NewRemoteDataConverter(
+				converter.GetDefaultDataConverter(),
+				converter.RemoteDataConverterOptions{
+					Endpoint: dcRemote,
+				},
+			),
+		)
+	}
+
 	dcPlugin := ctx.String(FlagDataConverterPlugin)
 	if dcPlugin != "" {
 		dataConverter, err := plugin.NewDataConverterPlugin(dcPlugin)

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -219,6 +219,7 @@ var (
 	FlagInputDirectory                = "input-directory"
 	FlagAutoConfirm                   = "auto-confirm"
 	FlagDataConverterPlugin           = "data-converter-plugin"
+	FlagRemoteDataConverterEndpoint   = "remote-data-converter-endpoint"
 	FlagWebURL                        = "web-ui-url"
 	FlagHeadersProviderPlugin         = "headers-provider-plugin"
 	FlagHeadersProviderPluginOptions  = "headers-provider-plugin-options"

--- a/cli_curr/app.go
+++ b/cli_curr/app.go
@@ -250,10 +250,13 @@ func loadPlugins(c *cli.Context) error {
 	dcRemote := c.String(FlagRemoteDataConverter)
 	if dcRemote != "" {
 		dataconverter.SetCurrent(
-			converter.NewRemoteEncoderDataConverter(
-				converter.RemoteEncoderDataConverterOptions{
-					Endpoint: dcRemote,
-				},
+			converter.NewEncodingDataConverter(
+				converter.GetDefaultDataConverter(),
+				converter.NewRemotePayloadEncoder(
+					converter.RemotePayloadEncoderOptions{
+						Endpoint: dcRemote,
+					},
+				),
 			),
 		)
 	}

--- a/cli_curr/app.go
+++ b/cli_curr/app.go
@@ -114,10 +114,10 @@ func NewCliApp() *cli.App {
 			EnvVar: "TEMPORAL_CLI_PLUGIN_DATA_CONVERTER",
 		},
 		&cli.StringFlag{
-			Name:   FlagRemoteDataConverter,
+			Name:   FlagRemoteDataConverterEndpoint,
 			Value:  "",
 			Usage:  "Remote data converter endpoint",
-			EnvVar: "TEMPORAL_CLI_REMOTE_DATA_CONVERTER",
+			EnvVar: "TEMPORAL_CLI_REMOTE_DATA_CONVERTER_ENDPOINT",
 		},
 	}
 	app.Commands = []cli.Command{
@@ -247,16 +247,14 @@ func NewCliApp() *cli.App {
 }
 
 func loadPlugins(c *cli.Context) error {
-	dcRemote := c.String(FlagRemoteDataConverter)
+	dcRemote := c.String(FlagRemoteDataConverterEndpoint)
 	if dcRemote != "" {
 		dataconverter.SetCurrent(
-			converter.NewEncodingDataConverter(
+			converter.NewRemoteDataConverter(
 				converter.GetDefaultDataConverter(),
-				converter.NewRemotePayloadEncoder(
-					converter.RemotePayloadEncoderOptions{
-						Endpoint: dcRemote,
-					},
-				),
+				converter.RemoteDataConverterOptions{
+					Endpoint: dcRemote,
+				},
 			),
 		)
 	}

--- a/cli_curr/app.go
+++ b/cli_curr/app.go
@@ -34,6 +34,8 @@ import (
 	"github.com/temporalio/tctl/cli_curr/headersprovider"
 	"github.com/temporalio/tctl/cli_curr/plugin"
 	"go.temporal.io/server/common/headers"
+
+	"go.temporal.io/sdk/converter"
 )
 
 // SetFactory is used to set the ClientFactory global
@@ -110,6 +112,12 @@ func NewCliApp() *cli.App {
 			Value:  "",
 			Usage:  "Data converter plugin executable name",
 			EnvVar: "TEMPORAL_CLI_PLUGIN_DATA_CONVERTER",
+		},
+		&cli.StringFlag{
+			Name:   FlagRemoteDataConverter,
+			Value:  "",
+			Usage:  "Remote data converter endpoint",
+			EnvVar: "TEMPORAL_CLI_REMOTE_DATA_CONVERTER",
 		},
 	}
 	app.Commands = []cli.Command{
@@ -239,6 +247,17 @@ func NewCliApp() *cli.App {
 }
 
 func loadPlugins(c *cli.Context) error {
+	dcRemote := c.String(FlagRemoteDataConverter)
+	if dcRemote != "" {
+		dataconverter.SetCurrent(
+			converter.NewRemoteEncoderDataConverter(
+				converter.RemoteEncoderDataConverterOptions{
+					Endpoint: dcRemote,
+				},
+			),
+		)
+	}
+
 	dcPlugin := c.String(FlagDataConverterPlugin)
 	if dcPlugin != "" {
 		dataConverter, err := plugin.NewDataConverterPlugin(dcPlugin)

--- a/cli_curr/dataconverter/dataconverter.go
+++ b/cli_curr/dataconverter/dataconverter.go
@@ -22,16 +22,18 @@
 
 package dataconverter
 
-import "go.temporal.io/sdk/converter"
+import (
+	"go.temporal.io/sdk/converter"
+)
 
 var (
-	dataConverter = converter.GetDefaultDataConverter()
+	defaultDataConverter = converter.GetDefaultDataConverter()
 )
 
 func SetCurrent(dc converter.DataConverter) {
-	dataConverter = dc
+	defaultDataConverter = dc
 }
 
 func GetCurrent() converter.DataConverter {
-	return dataConverter
+	return defaultDataConverter
 }

--- a/cli_curr/flags.go
+++ b/cli_curr/flags.go
@@ -228,6 +228,7 @@ const (
 	FlagUpperShardBound                       = "upper_shard_bound"
 	FlagInputDirectory                        = "input_directory"
 	FlagAutoConfirm                           = "auto_confirm"
+	FlagRemoteDataConverter                   = "remote-data-converter"
 	FlagDataConverterPlugin                   = "data_converter_plugin"
 	FlagDataConverterPluginWithAlias          = FlagDataConverterPlugin + ", dcp"
 	FlagWebURL                                = "web_ui_url"

--- a/cli_curr/flags.go
+++ b/cli_curr/flags.go
@@ -228,7 +228,7 @@ const (
 	FlagUpperShardBound                       = "upper_shard_bound"
 	FlagInputDirectory                        = "input_directory"
 	FlagAutoConfirm                           = "auto_confirm"
-	FlagRemoteDataConverter                   = "remote_data_converter"
+	FlagRemoteDataConverterEndpoint           = "remote_data_converter_endpoint"
 	FlagDataConverterPlugin                   = "data_converter_plugin"
 	FlagDataConverterPluginWithAlias          = FlagDataConverterPlugin + ", dcp"
 	FlagWebURL                                = "web_ui_url"

--- a/cli_curr/flags.go
+++ b/cli_curr/flags.go
@@ -228,7 +228,7 @@ const (
 	FlagUpperShardBound                       = "upper_shard_bound"
 	FlagInputDirectory                        = "input_directory"
 	FlagAutoConfirm                           = "auto_confirm"
-	FlagRemoteDataConverter                   = "remote-data-converter"
+	FlagRemoteDataConverter                   = "remote_data_converter"
 	FlagDataConverterPlugin                   = "data_converter_plugin"
 	FlagDataConverterPluginWithAlias          = FlagDataConverterPlugin + ", dcp"
 	FlagWebURL                                = "web_ui_url"

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/temporalio/tctl
 
 go 1.17
 
-replace go.temporal.io/sdk => github.com/temporalio/sdk-go v1.13.1-0.20220207161017-b2a682807bad
+replace go.temporal.io/sdk => github.com/temporalio/sdk-go v1.13.2-0.20220222144957-856f5c2751d5
 
 require (
 	github.com/fatih/color v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/temporalio/tctl
 
 go 1.17
 
+replace go.temporal.io/sdk => github.com/temporalio/sdk-go v1.13.1-0.20220206141821-eb0f2d2a6719
+
 require (
 	github.com/fatih/color v1.13.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/temporalio/tctl
 
 go 1.17
 
-replace go.temporal.io/sdk => github.com/temporalio/sdk-go v1.13.1-0.20220206141821-eb0f2d2a6719
+replace go.temporal.io/sdk => github.com/temporalio/sdk-go v1.13.1-0.20220207161017-b2a682807bad
 
 require (
 	github.com/fatih/color v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -480,8 +480,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temporalio/ringpop-go v0.0.0-20211012191444-6f91b5915e95 h1:8G34e73qtrkG9sDFcSC8uot0np3e6BLoMZxleTcpUiA=
 github.com/temporalio/ringpop-go v0.0.0-20211012191444-6f91b5915e95/go.mod h1:Ek9J8CAfI1IwVSqHpTOgj7FjzRSJ5SM/ud52eCmkhsw=
-github.com/temporalio/sdk-go v1.13.1-0.20220207161017-b2a682807bad h1:XqKzt8UtIaAg5OziNle+jzTl9ePHBP20U5oTAWHtPyU=
-github.com/temporalio/sdk-go v1.13.1-0.20220207161017-b2a682807bad/go.mod h1:TCof7U/xas2FyDnx/UUEv4c/O/S41Lnhva+6JVer+Jo=
+github.com/temporalio/sdk-go v1.13.2-0.20220222144957-856f5c2751d5 h1:J1RGWPaB3YVxs1AM+utFjpEWiiMCvtgFW2+Xjpysqig=
+github.com/temporalio/sdk-go v1.13.2-0.20220222144957-856f5c2751d5/go.mod h1:TCof7U/xas2FyDnx/UUEv4c/O/S41Lnhva+6JVer+Jo=
 github.com/temporalio/tctl-kit v0.0.0-20211220044822-28c2391a9ce4 h1:NCIx/Wo3uIX+cHqZcqPWfmMh9Y9NPghE6eGQNJBb65g=
 github.com/temporalio/tctl-kit v0.0.0-20211220044822-28c2391a9ce4/go.mod h1:nwajnpE9EUnMfoXt58tObJL0S4SdYwoWor6sdm89Iug=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=

--- a/go.sum
+++ b/go.sum
@@ -480,6 +480,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temporalio/ringpop-go v0.0.0-20211012191444-6f91b5915e95 h1:8G34e73qtrkG9sDFcSC8uot0np3e6BLoMZxleTcpUiA=
 github.com/temporalio/ringpop-go v0.0.0-20211012191444-6f91b5915e95/go.mod h1:Ek9J8CAfI1IwVSqHpTOgj7FjzRSJ5SM/ud52eCmkhsw=
+github.com/temporalio/sdk-go v1.13.1-0.20220206141821-eb0f2d2a6719 h1:7lv8938y2kIPdHcgJHDZIsC7sExJpeol9XBSCcG5amc=
+github.com/temporalio/sdk-go v1.13.1-0.20220206141821-eb0f2d2a6719/go.mod h1:TCof7U/xas2FyDnx/UUEv4c/O/S41Lnhva+6JVer+Jo=
 github.com/temporalio/tctl-kit v0.0.0-20211220044822-28c2391a9ce4 h1:NCIx/Wo3uIX+cHqZcqPWfmMh9Y9NPghE6eGQNJBb65g=
 github.com/temporalio/tctl-kit v0.0.0-20211220044822-28c2391a9ce4/go.mod h1:nwajnpE9EUnMfoXt58tObJL0S4SdYwoWor6sdm89Iug=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
@@ -537,11 +539,9 @@ go.opentelemetry.io/otel/sdk/metric v0.25.0/go.mod h1:G4xzj4LvC6xDDSsVXpvRVclQCb
 go.opentelemetry.io/otel/trace v1.2.0 h1:Ys3iqbqZhcf28hHzrm5WAquMkDHNZTUkw7KHbuNjej0=
 go.opentelemetry.io/otel/trace v1.2.0/go.mod h1:N5FLswTubnxKxOJHM7XZC074qpeEdLy3CgAVsdMucK0=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
-go.temporal.io/api v1.5.0/go.mod h1:BqKxEJJYdxb5dqf0ODfzfMxh8UEQ5L3zKS51FiIYYkA=
+go.temporal.io/api v1.6.1-0.20211110205628-60c98e9cbfe2/go.mod h1:IlUgOTGfmJuOkGrCZdptNxyXKE9CQz6oOx7/aH9bFY4=
 go.temporal.io/api v1.7.1-0.20220126215723-f2aa2e2ad71d h1:uqiiUinsGlZ7R6M74B8Md2XXbjkoinQdhbFrY7coh1o=
 go.temporal.io/api v1.7.1-0.20220126215723-f2aa2e2ad71d/go.mod h1:Qy3l0Bw9C1RcToB+kfsI0lkrZYbDLgC9pzi6OYYJ/aE=
-go.temporal.io/sdk v1.12.0 h1:QkqOpmgXVnHHCFP9HbSbyrF3jYgLBKY/3NdZyR7e5nQ=
-go.temporal.io/sdk v1.12.0/go.mod h1:lSp3lH1lI0TyOsus0arnO3FYvjVXBZGi/G7DjnAnm6o=
 go.temporal.io/server v1.13.1-0.20220126223326-a69c45c3147f h1:6tQMKSzJhATpTMgxeeSgBCi/+zrU/T6krIiPY2E/g5Q=
 go.temporal.io/server v1.13.1-0.20220126223326-a69c45c3147f/go.mod h1:3pmB9LML/u94Naqe/gIgkJx/sPJCM/QGF2jEqjSq5mk=
 go.temporal.io/version v0.3.0/go.mod h1:UA9S8/1LaKYae6TyD9NaPMJTZb911JcbqghI2CBSP78=
@@ -663,7 +663,7 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211109214657-ef0fda0de508/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba h1:6u6sik+bn/y7vILcYkK3iwTBWN7WtBvB0+SZswQnbf8=
 golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -759,11 +759,11 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -953,6 +953,7 @@ google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4/go.mod h1:eFjDcFEc
 google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211008145708-270636b82663/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211016002631-37fc39342514/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211104193956-4c6863e31247/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350 h1:YxHp5zqIcAShDEvRr5/0rVESVS+njYF68PSdazrNLJo=
 google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
@@ -982,6 +983,7 @@ google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQ
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
+google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=

--- a/go.sum
+++ b/go.sum
@@ -480,8 +480,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temporalio/ringpop-go v0.0.0-20211012191444-6f91b5915e95 h1:8G34e73qtrkG9sDFcSC8uot0np3e6BLoMZxleTcpUiA=
 github.com/temporalio/ringpop-go v0.0.0-20211012191444-6f91b5915e95/go.mod h1:Ek9J8CAfI1IwVSqHpTOgj7FjzRSJ5SM/ud52eCmkhsw=
-github.com/temporalio/sdk-go v1.13.1-0.20220206141821-eb0f2d2a6719 h1:7lv8938y2kIPdHcgJHDZIsC7sExJpeol9XBSCcG5amc=
-github.com/temporalio/sdk-go v1.13.1-0.20220206141821-eb0f2d2a6719/go.mod h1:TCof7U/xas2FyDnx/UUEv4c/O/S41Lnhva+6JVer+Jo=
+github.com/temporalio/sdk-go v1.13.1-0.20220207161017-b2a682807bad h1:XqKzt8UtIaAg5OziNle+jzTl9ePHBP20U5oTAWHtPyU=
+github.com/temporalio/sdk-go v1.13.1-0.20220207161017-b2a682807bad/go.mod h1:TCof7U/xas2FyDnx/UUEv4c/O/S41Lnhva+6JVer+Jo=
 github.com/temporalio/tctl-kit v0.0.0-20211220044822-28c2391a9ce4 h1:NCIx/Wo3uIX+cHqZcqPWfmMh9Y9NPghE6eGQNJBb65g=
 github.com/temporalio/tctl-kit v0.0.0-20211220044822-28c2391a9ce4/go.mod h1:nwajnpE9EUnMfoXt58tObJL0S4SdYwoWor6sdm89Iug=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=


### PR DESCRIPTION
## What was changed

Added support for the new remote data encoder protocol.

## Why?

This avoids the need to use a data converter plugin or write the data converter in Go.

## Checklist

1. How was this tested:
Tested against an application running a remote data encoder using the Go SDK.

2. Any docs updates needed?
Yes, tctl documentation should be updated to explain remote data encoder usage.