### PR TITLE
Add repo and branch info when triggering Docker builds

### DIFF
--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -16,11 +16,18 @@ jobs:
         shell: bash
 
     steps:
+      - name: Get git branch name
+        id: get_branch
+        run: |
+          echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+
       - name: Dispatch docker builds Github Action
         env:
           PAT: ${{ secrets.COMMANDER_DATA_TOKEN }}
           PARENT_REPO: temporalio/docker-builds
-          PARENT_BRANCH: main
+          PARENT_BRANCH: ${{ toJSON('main') }}
           WORKFLOW_ID: update-submodules.yml
+          REPO: ${{ toJSON('tctl') }}
+          BRANCH: ${{ toJSON(steps.get_branch.outputs.branch) }}
         run: |
-          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ env.PAT }}" https://api.github.com/repos/${{ env.PARENT_REPO }}/actions/workflows/${{ env.WORKFLOW_ID }}/dispatches -d '{"ref":"${{ env.PARENT_BRANCH }}"}'
+          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"' }}'


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

As per changes in https://github.com/temporalio/docker-builds/pull/23
Adds info regarding the submodule(or the current repo) and the branch name

## Why?
<!-- Tell your future self why have you made these changes -->

Automating release process & patch releases

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Tested the code with personal repos and simulating the changes:
https://github.com/feedmeapples/gha-parent
https://github.com/feedmeapples/gha-child

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
