### PR TITLE
Apply default for max field length.

### DIFF
--- a/cli/workflowCommands.go
+++ b/cli/workflowCommands.go
@@ -306,10 +306,7 @@ func (h *historyIterator) Next() (interface{}, error) {
 
 // helper function to print workflow progress with time refresh every second
 func printWorkflowProgress(c *cli.Context, wid, rid string, watch bool) error {
-	var maxFieldLength int
-	if c.IsSet(FlagMaxFieldLength) {
-		maxFieldLength = c.Int(FlagMaxFieldLength)
-	}
+	var maxFieldLength = c.Int(FlagMaxFieldLength)
 	sdkClient, err := getSDKClient(c)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What was changed
Always apply the value of the max fields flag, regardless if it was specifically set or defaulted.

## Why?
Prior to this change the default was ignored as we specifically checked if the
flag was set before applying its value (default or otherwise). This resulted
in the default behaviour actually using 0 via the default int value.