### PR TITLE
Rename list archived workflows command for consistency

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -426,7 +426,7 @@ func (s *cliAppSuite) TestListWorkflow_Open_WithWorkflowType() {
 
 func (s *cliAppSuite) TestListArchivedWorkflow() {
 	s.sdkClient.On("ListArchivedWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.ListArchivedWorkflowExecutionsResponse{}, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "listarchived", "--query", "some query string"})
+	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "list-archived", "--query", "some query string"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -66,7 +66,7 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:  "listarchived",
+			Name:  "list-archived",
 			Usage: "list archived workflow executions",
 			Flags: append(flagsForListArchived, flags.FlagsForPaginationAndRendering...),
 			Action: func(c *cli.Context) error {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Renamed `tctl workflow listarchived` to `tctl workflow list-archived`

## Why?
<!-- Tell your future self why have you made these changes -->

consistency in naming with other commands

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
