### PR TITLE
Address tasks not recognized as failed with non-determenistic cause

### DIFF
--- a/cli/workflowCommands.go
+++ b/cli/workflowCommands.go
@@ -1290,8 +1290,9 @@ func isLastEventWorkflowTaskFailedWithNonDeterminism(ctx context.Context, namesp
 	if workflowTaskFailedEvent != nil {
 		attr := workflowTaskFailedEvent.GetWorkflowTaskFailedEventAttributes()
 
-		if attr.GetCause() == enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE ||
-			strings.Contains(attr.GetFailure().GetMessage(), "nondeterministic") {
+		if (attr.GetCause() == enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR) ||
+			(attr.GetCause() == enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE ||
+				strings.Contains(attr.GetFailure().GetMessage(), "nondeterministic")) {
 			fmt.Printf("found non determnistic workflow wid:%v, rid:%v, orignalStartTime:%v \n", wid, rid, timestamp.TimeValue(firstEvent.GetEventTime()))
 			return true, nil
 		}

--- a/cli_curr/workflowCommands.go
+++ b/cli_curr/workflowCommands.go
@@ -1757,8 +1757,9 @@ func isLastEventWorkflowTaskFailedWithNonDeterminism(ctx context.Context, namesp
 	if workflowTaskFailedEvent != nil {
 		attr := workflowTaskFailedEvent.GetWorkflowTaskFailedEventAttributes()
 
-		if attr.GetCause() == enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE ||
-			strings.Contains(attr.GetFailure().GetMessage(), "nondeterministic") {
+		if (attr.GetCause() == enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR) ||
+			(attr.GetCause() == enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE ||
+				strings.Contains(attr.GetFailure().GetMessage(), "nondeterministic")) {
 			fmt.Printf("found non determnistic workflow wid:%v, rid:%v, orignalStartTime:%v \n", wid, rid, timestamp.TimeValue(firstEvent.GetEventTime()))
 			return true, nil
 		}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

When resetting workflows in batch, start also looking for `WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR` causes to identify failures of non-deterministic type

## Why?
<!-- Tell your future self why have you made these changes -->

resolve #186

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
