### PR TITLE
Move workflow observe under show command as a flag

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -233,6 +233,18 @@ func (s *cliAppSuite) TestShowHistory() {
 	s.sdkClient.AssertExpectations(s.T())
 }
 
+func (s *cliAppSuite) TestShowHistoryWithFollow() {
+	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", "", mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
+	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "show", "--workflow-id", "wid", "--follow"})
+	s.Nil(err)
+	s.sdkClient.AssertExpectations(s.T())
+
+	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", "", mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
+	err = s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "show", "--workflow-id", "wid", "--fields", "long", "--follow"})
+	s.Nil(err)
+	s.sdkClient.AssertExpectations(s.T())
+}
+
 func (s *cliAppSuite) TestRunWorkflow() {
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", mock.Anything, mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
@@ -470,18 +482,6 @@ func (s *cliAppSuite) TestDescribeTaskQueue() {
 func (s *cliAppSuite) TestDescribeTaskQueue_Activity() {
 	s.sdkClient.On("DescribeTaskQueue", mock.Anything, mock.Anything, mock.Anything).Return(describeTaskQueueResponse, nil).Once()
 	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "task-queue", "describe", "--task-queue", "test-taskQueue", "--task-queue-type", "activity"})
-	s.Nil(err)
-	s.sdkClient.AssertExpectations(s.T())
-}
-
-func (s *cliAppSuite) TestObserveWorkflow() {
-	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", "", mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "observe", "--workflow-id", "wid"})
-	s.Nil(err)
-	s.sdkClient.AssertExpectations(s.T())
-
-	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", "", mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
-	err = s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "observe", "--workflow-id", "wid", "--fields", "long"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -228,6 +228,7 @@ var (
 	FlagVersion                       = "version"
 	FlagPort                          = "port"
 	FlagEnableConnection              = "enable-connection"
+	FlagFollow                        = "follow"
 
 	FlagProtoType  = "type"
 	FlagHexData    = "hex-data"
@@ -266,6 +267,11 @@ var flagsForShowWorkflow = []cli.Flag{
 	&cli.BoolFlag{
 		Name:  FlagResetPointsOnly,
 		Usage: "Only show events that are eligible for reset",
+	},
+	&cli.BoolFlag{
+		Name:  FlagFollow,
+		Usage: "Follow the progress of workflow execution",
+		Value: false,
 	},
 }
 

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -82,15 +82,6 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:    "observe",
-			Aliases: []string{"o"},
-			Usage:   "Show the progress of workflow history",
-			Flags:   append(append(flagsForExecution, flagsForShowWorkflow...), flags.FlagsForPaginationAndRendering...),
-			Action: func(c *cli.Context) error {
-				return ObserveHistory(c)
-			},
-		},
-		{
 			Name:  "query",
 			Usage: "Query workflow execution",
 			Flags: append(flagsForStackTraceQuery,

--- a/cli/workflowCommands.go
+++ b/cli/workflowCommands.go
@@ -911,15 +911,9 @@ func ShowHistory(c *cli.Context) error {
 	wid := c.String(FlagWorkflowID)
 	rid := c.String(FlagRunID)
 
-	return printWorkflowProgress(c, wid, rid, false)
-}
+	follow := c.Bool(FlagFollow)
 
-// ObserveHistory show the process of running workflow
-func ObserveHistory(c *cli.Context) error {
-	wid := c.String(FlagWorkflowID)
-	rid := c.String(FlagRunID)
-
-	return printWorkflowProgress(c, wid, rid, true)
+	return printWorkflowProgress(c, wid, rid, follow)
 }
 
 // ResetWorkflow reset workflow


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Removed `workflow observe` command
- added it under `workflow show`  as a `--follow` flag

## Why?
<!-- Tell your future self why have you made these changes -->

~ same command 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
