### PR TITLE
Print execution time when describing workflow

### DIFF
--- a/cli/workflow_commands.go
+++ b/cli/workflow_commands.go
@@ -738,6 +738,7 @@ func convertDescribeWorkflowExecutionResponse(c *cli.Context, resp *workflowserv
 		SearchAttributes:     convertSearchAttributes(c, info.GetSearchAttributes()),
 		AutoResetPoints:      info.GetAutoResetPoints(),
 		StateTransitionCount: info.GetStateTransitionCount(),
+		ExecutionTime:        info.GetExecutionTime(),
 	}
 
 	var pendingActivitiesStr []*clispb.PendingActivityInfo


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Starts printing Execution Time with `tctl workflow describe`

## Why?
<!-- Tell your future self why have you made these changes -->

resolve #105

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

```
./tctl w d -wid f0f0aa_Running

{
  "executionConfig": {
    "taskQueue": {
      "name": "rainbow-statuses"
...
"workflowExecutionInfo": {
"execution": {
      "workflowId": "f0f0aa_Running",
      "runId": "afc19ece-40eb-49ac-babe-b632e36093e5"
    },
"executionTime": "2022-05-18T17:06:16.438730163Z",
...
}
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
