### PR TITLE
Fix search attribute parsing when starting workflows in .17 beta

### DIFF
--- a/cli/defs.go
+++ b/cli/defs.go
@@ -66,8 +66,6 @@ const (
 
 	workflowStatusNotSet = -1
 	showErrorStackEnv    = `TEMPORAL_CLI_SHOW_STACKS`
-
-	searchAttrInputSeparator = "|"
 )
 
 var envKeysForUserName = []string{

--- a/cli/workflow_commands.go
+++ b/cli/workflow_commands.go
@@ -190,30 +190,25 @@ func formatInputsForDisplay(inputs []interface{}) string {
 }
 
 func unmarshalSearchAttrFromCLI(c *cli.Context) (map[string]interface{}, error) {
-	sanitize := func(val string) []string {
-		trimmedVal := strings.TrimSpace(val)
-		if len(trimmedVal) == 0 {
-			return nil
-		}
-		splitVal := strings.Split(trimmedVal, searchAttrInputSeparator)
-		result := make([]string, len(splitVal))
-		for i, v := range splitVal {
+	sanitize := func(val []string) []string {
+		result := make([]string, len(val))
+		for i, v := range val {
 			result[i] = strings.TrimSpace(v)
 		}
 		return result
 	}
 
-	searchAttrKeys := sanitize(c.String(FlagSearchAttributeKey))
+	searchAttrKeys := sanitize(c.StringSlice(FlagSearchAttributeKey))
 	if len(searchAttrKeys) == 0 {
 		return nil, nil
 	}
-	rawSearchAttrVals := sanitize(c.String(FlagSearchAttributeValue))
+	rawSearchAttrVals := sanitize(c.StringSlice(FlagSearchAttributeValue))
 	if len(rawSearchAttrVals) == 0 {
 		return nil, nil
 	}
 
 	if len(searchAttrKeys) != len(rawSearchAttrVals) {
-		return nil, fmt.Errorf("uneven number of search attributes keys (%d): %v and values(%d): %v", len(searchAttrKeys), searchAttrKeys, len(rawSearchAttrVals), rawSearchAttrVals)
+		return nil, fmt.Errorf("uneven number of search attributes keys (%d): %v and values (%d): %v", len(searchAttrKeys), searchAttrKeys, len(rawSearchAttrVals), rawSearchAttrVals)
 	}
 
 	fields := make(map[string]interface{}, len(searchAttrKeys))


### PR DESCRIPTION
## What was changed
This fixes the ability to start workflows without search attributes in the 0.17 beta.

## Why?
A bug in the parsing code would pass a bogus search attribute to the server when none were specified on the command line:
```
client.StartWorkflowOptions { SearchAttributes: { "[]": "" } }
```

## Checklist
2. How was this tested:
There are some new tests, as well as new assertions in old tests which failed before changing the parsing logic.

3. Any docs updates needed?
Nope!