### PR TITLE
Bump versions to 1.16.2 and 1.17.0-alpha.2

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -51,7 +51,7 @@ func NewCliApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "tctl"
 	app.Usage = "A command-line tool for Temporal users"
-	app.Version = "1.17.0-alpha.1"
+	app.Version = "1.17.0-alpha.2"
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:    FlagAddress,

--- a/cli/headers/headers.go
+++ b/cli/headers/headers.go
@@ -41,7 +41,7 @@ const (
 const (
 	ClientNameCLI = "temporal-cli"
 
-	CLIVersion = "1.16.1"
+	CLIVersion = "1.16.2"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Bump versions to `1.16.2` and `1.17.0-alpha.2`.

## Why?
<!-- Tell your future self why have you made these changes -->
To support new server release.
