### PR TITLE
Add workflow trace command

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -250,8 +250,8 @@ var (
 	FlagPause                         = "pause"
 	FlagUnpause                       = "unpause"
 	FlagShowAll                       = "all"
-	FlagChildsDepth                   = "depth"
-	FlagChildsDepthAlias              = []string{"d"}
+	FlagDepth                         = "depth"
+	FlagDepthAlias                    = []string{"d"}
 
 	FlagProtoType  = "type"
 	FlagHexData    = "hex-data"
@@ -449,8 +449,8 @@ var flagsForStackTraceQuery = append(flagsForExecution, []cli.Flag{
 
 var flagsForTraceWorkflow = []cli.Flag{
 	&cli.IntFlag{
-		Name:    FlagChildsDepth,
-		Aliases: FlagChildsDepthAlias,
+		Name:    FlagDepth,
+		Aliases: FlagDepthAlias,
 		Value:   -1,
 		Usage:   "Number of child workflows to expand, -1 to expand all child workflows",
 	},
@@ -463,6 +463,7 @@ var flagsForTraceWorkflow = []cli.Flag{
 	&cli.BoolFlag{
 		Name:  FlagShowAll,
 		Value: false,
-		Usage: "Display all child workflows within the specified depth",
+		Usage: "Shows all the child workflows rather than folding closed executions. " +
+			"This will fetch more history events, so it will impact performance for big workflows",
 	},
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -25,6 +25,7 @@
 package cli
 
 import (
+	"fmt"
 	"github.com/temporalio/tctl-kit/pkg/output"
 	"github.com/urfave/cli/v2"
 )
@@ -249,7 +250,6 @@ var (
 	FlagPauseOnFailure                = "pause-on-failure"
 	FlagPause                         = "pause"
 	FlagUnpause                       = "unpause"
-	FlagShowAll                       = "all"
 	FlagFold                          = "fold"
 	FlagNoFold                        = "no-fold"
 	FlagDepth                         = "depth"
@@ -464,8 +464,8 @@ var flagsForTraceWorkflow = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:  FlagFold,
-		Usage: "Workflow statuses to fold, comma separated.",
-		Value: "Completed,Canceled,Terminated",
+		Usage: fmt.Sprintf("Statuses for which child workflows will be folded in (this will reduce the number of information fetched and displayed). Case-insensitive and ignored if --%s supplied", FlagNoFold),
+		Value: "completed,canceled,terminated",
 	},
 	&cli.BoolFlag{
 		Name:  FlagNoFold,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -250,6 +250,8 @@ var (
 	FlagPause                         = "pause"
 	FlagUnpause                       = "unpause"
 	FlagShowAll                       = "all"
+	FlagFold                          = "fold"
+	FlagNoFold                        = "no-fold"
 	FlagDepth                         = "depth"
 	FlagDepthAlias                    = []string{"d"}
 
@@ -460,10 +462,13 @@ var flagsForTraceWorkflow = []cli.Flag{
 		Value:   10,
 		Usage:   "Request concurrency",
 	},
+	&cli.StringFlag{
+		Name:  FlagFold,
+		Usage: "Workflow statuses to fold, comma separated.",
+		Value: "Completed,Canceled,Terminated",
+	},
 	&cli.BoolFlag{
-		Name:  FlagShowAll,
-		Value: false,
-		Usage: "Shows all the child workflows rather than folding closed executions. " +
-			"This will fetch more history events, so it will impact performance for big workflows",
+		Name:  FlagNoFold,
+		Usage: "Disable folding. All child workflows within the set depth will be fetched and displayed",
 	},
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -215,6 +215,7 @@ var (
 	FlagTLSServerName                 = "tls-server-name"
 	FlagLastMessageID                 = "last-message-id"
 	FlagConcurrency                   = "concurrency"
+	FlagConcurrencyAlias              = []string{"c"}
 	FlagReportRate                    = "report-rate"
 	FlagLowerShardBound               = "lower-shard-bound"
 	FlagUpperShardBound               = "upper-shard-bound"
@@ -248,6 +249,9 @@ var (
 	FlagPauseOnFailure                = "pause-on-failure"
 	FlagPause                         = "pause"
 	FlagUnpause                       = "unpause"
+	FlagShowAll                       = "all"
+	FlagChildsDepth                   = "depth"
+	FlagChildsDepthAlias              = []string{"d"}
 
 	FlagProtoType  = "type"
 	FlagHexData    = "hex-data"
@@ -442,3 +446,23 @@ var flagsForStackTraceQuery = append(flagsForExecution, []cli.Flag{
 		Usage:   "Optional flag to reject queries based on Workflow state. Valid values are \"not_open\" and \"not_completed_cleanly\"",
 	},
 }...)
+
+var flagsForTraceWorkflow = []cli.Flag{
+	&cli.IntFlag{
+		Name:    FlagChildsDepth,
+		Aliases: FlagChildsDepthAlias,
+		Value:   -1,
+		Usage:   "Number of child workflows to expand, -1 to expand all child workflows",
+	},
+	&cli.IntFlag{
+		Name:    FlagConcurrency,
+		Aliases: FlagConcurrencyAlias,
+		Value:   10,
+		Usage:   "Request concurrency",
+	},
+	&cli.BoolFlag{
+		Name:  FlagShowAll,
+		Value: false,
+		Usage: "Display all child workflows within the specified depth",
+	},
+}

--- a/cli/util.go
+++ b/cli/util.go
@@ -765,16 +765,28 @@ func ensureNonNil[T any, P ~*T](ptr *P) {
 func listWorkflowExecutionStatusNames() string {
 	var names []string
 	for _, name := range enumspb.WorkflowExecutionStatus_name {
-		names = append(names, name)
+		names = append(names, strings.ToLower(name))
 	}
 	return strings.Join(names, ", ")
+}
+
+// findWorkflowStatusValue finds a WorkflowExecutionStatus by its name. This search is case-insensitive.
+func findWorkflowStatusValue(name string) (enumspb.WorkflowExecutionStatus, bool) {
+	lowerName := strings.ToLower(name)
+	for key, value := range enumspb.WorkflowExecutionStatus_value {
+		if lowerName == strings.ToLower(key) {
+			return enumspb.WorkflowExecutionStatus(value), true
+		}
+	}
+
+	return 0, false
 }
 
 func parseFoldStatusList(flagValue string) ([]enumspb.WorkflowExecutionStatus, error) {
 	var statusList []enumspb.WorkflowExecutionStatus
 	for _, value := range strings.Split(flagValue, ",") {
-		if status, ok := enumspb.WorkflowExecutionStatus_value[value]; ok {
-			statusList = append(statusList, enumspb.WorkflowExecutionStatus(status))
+		if status, ok := findWorkflowStatusValue(value); ok {
+			statusList = append(statusList, status)
 		} else {
 			return nil,
 				fmt.Errorf("invalid status \"%s\" for fold flag. Valid values: %s", value, listWorkflowExecutionStatusNames())

--- a/cli/util.go
+++ b/cli/util.go
@@ -761,3 +761,24 @@ func ensureNonNil[T any, P ~*T](ptr *P) {
 		*ptr = new(T)
 	}
 }
+
+func listWorkflowExecutionStatusNames() string {
+	var names []string
+	for _, name := range enumspb.WorkflowExecutionStatus_name {
+		names = append(names, name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func parseFoldStatusList(flagValue string) ([]enumspb.WorkflowExecutionStatus, error) {
+	var statusList []enumspb.WorkflowExecutionStatus
+	for _, value := range strings.Split(flagValue, ",") {
+		if status, ok := enumspb.WorkflowExecutionStatus_value[value]; ok {
+			statusList = append(statusList, enumspb.WorkflowExecutionStatus(status))
+		} else {
+			return nil,
+				fmt.Errorf("invalid status \"%s\" for fold flag. Valid values: %s", value, listWorkflowExecutionStatusNames())
+		}
+	}
+	return statusList, nil
+}

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -25,6 +25,7 @@
 package cli
 
 import (
+	enumspb "go.temporal.io/api/enums/v1"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -88,4 +89,51 @@ func (s *utilSuite) TestStringToEnum_MapEmptyEnum() {
 	result, err := stringToEnum("Timer", enumValues)
 	s.Error(err)
 	s.Equal(result, int32(0))
+}
+
+func (s *utilSuite) TestParseFoldStatusList() {
+	tests := map[string]struct {
+		value   string
+		want    []enumspb.WorkflowExecutionStatus
+		wantErr bool
+	}{
+		"default values": {
+			value: "Completed,Canceled,Terminated",
+			want: []enumspb.WorkflowExecutionStatus{
+				enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+				enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED,
+				enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+			},
+		},
+		"no values": {
+			value: "",
+			want:  nil,
+		},
+		"invalid": {
+			value:   "Foobar",
+			wantErr: true,
+		},
+		"all values": {
+			value: "Running,Completed,Failed,Canceled,Terminated,ContinuedAsNew,TimedOut",
+			want: []enumspb.WorkflowExecutionStatus{
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+				enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+				enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED,
+				enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+				enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW,
+				enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT,
+			},
+		},
+	}
+	for name, tt := range tests {
+		s.Run(name, func() {
+			got, err := parseFoldStatusList(tt.value)
+			if tt.wantErr {
+				s.Error(err)
+			} else {
+				s.Equal(tt.want, got)
+			}
+		})
+	}
 }

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -98,7 +98,7 @@ func (s *utilSuite) TestParseFoldStatusList() {
 		wantErr bool
 	}{
 		"default values": {
-			value: "Completed,Canceled,Terminated",
+			value: "completed,canceled,terminated",
 			want: []enumspb.WorkflowExecutionStatus{
 				enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
 				enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED,
@@ -113,8 +113,20 @@ func (s *utilSuite) TestParseFoldStatusList() {
 			value:   "Foobar",
 			wantErr: true,
 		},
-		"all values": {
+		"title case": {
 			value: "Running,Completed,Failed,Canceled,Terminated,ContinuedAsNew,TimedOut",
+			want: []enumspb.WorkflowExecutionStatus{
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+				enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+				enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED,
+				enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+				enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW,
+				enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT,
+			},
+		},
+		"upper case": {
+			value: "RUNNING,COMPLETED,FAILED,CANCELED,TERMINATED,CONTINUEDASNEW,TIMEDOUT",
 			want: []enumspb.WorkflowExecutionStatus{
 				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 				enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -277,10 +277,11 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:   "trace",
-			Usage:  "Traces a workflow's execution with progress of its child workflows and activities",
-			Flags:  append(flagsForExecution, flagsForTraceWorkflow...),
-			Action: TraceWorkflow,
+			Name:    "trace",
+			Aliases: []string{"t"},
+			Usage:   "Traces a workflow's execution with progress of its child workflows and activities",
+			Flags:   append(flagsForExecution, flagsForTraceWorkflow...),
+			Action:  TraceWorkflow,
 		},
 	}
 }

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -276,5 +276,11 @@ func newWorkflowCommands() []*cli.Command {
 				return ResetInBatch(c)
 			},
 		},
+		{
+			Name:   "trace",
+			Usage:  "Traces a workflow's execution with progress of its child workflows and activities",
+			Flags:  append(flagsForExecution, flagsForTraceWorkflow...),
+			Action: TraceWorkflow,
+		},
 	}
 }

--- a/cli/workflow_commands.go
+++ b/cli/workflow_commands.go
@@ -1521,6 +1521,10 @@ func listArchivedWorkflows(c *cli.Context, sdkClient sdkclient.Client, npt []byt
 }
 
 func TraceWorkflow(c *cli.Context) error {
+	_, err := parseFoldStatusList(c.String(FlagFold))
+	if err != nil {
+		return err
+	}
 	fmt.Println("Trace hasn't been implemented yet.")
 	return nil
 }

--- a/cli/workflow_commands.go
+++ b/cli/workflow_commands.go
@@ -29,6 +29,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/api/workflowservice/v1"
 	"math/rand"
 	"os"
 	"reflect"
@@ -45,11 +47,9 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
-	"go.temporal.io/api/operatorservice/v1"
 	querypb "go.temporal.io/api/query/v1"
 	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
-	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	clispb "go.temporal.io/server/api/cli/v1"
 	"go.temporal.io/server/common"
@@ -1518,6 +1518,11 @@ func listArchivedWorkflows(c *cli.Context, sdkClient sdkclient.Client, npt []byt
 	}
 
 	return items, workflows.NextPageToken, nil
+}
+
+func TraceWorkflow(c *cli.Context) error {
+	fmt.Println("Trace hasn't been implemented yet.")
+	return nil
 }
 
 type eventRow struct {


### PR DESCRIPTION
## What was changed
This adds the base for the workflow `trace` command (called `texp` at Datadog) discussed in the Slack channel. 

## Why?
Rather than adding all the changes at once, I'd rather add the changes in small chunks so they're easier to digest and there's a proper feedback loop.

## Checklist

1. Opens the texp upstream (should I create a ticket?)

2. How was this tested:
- Manually (run `tctl w trace --help`, `tctl w trace --wid a --rid b`)

3. Any docs updates needed?
Not yet
