### PR TITLE
Add execution states necessary for trace

### DIFF
--- a/cli/trace/execution_state.go
+++ b/cli/trace/execution_state.go
@@ -1,0 +1,523 @@
+package sundial
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/failure/v1"
+	"go.temporal.io/api/history/v1"
+)
+
+// ExecutionState provides a common interface to any execution (Workflows, Activities and Timers in this case) updated through HistoryEvents.
+type ExecutionState interface {
+	Update(*history.HistoryEvent)
+	GetName() string
+	GetAttempt() int32
+	GetFailure() *failure.Failure
+	GetRetryState() enums.RetryState
+
+	GetDuration() *time.Duration
+	GetStartTime() *time.Time
+}
+
+// WorkflowExecutionState is a snapshot of the state of a WorkflowExecution.
+type WorkflowExecutionState struct {
+	Execution     *common.WorkflowExecution
+	Type          *common.WorkflowType
+	StartTime     *time.Time
+	CloseTime     *time.Time
+	Status        enums.WorkflowExecutionStatus
+	LastEventId   int64
+	HistoryLength int64
+	IsArchived    bool
+
+	// ChildStates contains all the executions contained by this WorkflowExecutionState in order of execution.
+	ChildStates []ExecutionState
+	// activityMap contains all the activities executed in the Workflow, indexed by the EVENT_TYPE_ACTIVITY_TASK_SCHEDULED event id
+	// Used to retrieve the activities from events
+	activityMap map[int64]*ActivityExecutionState
+	// childWfMap contains all the child workflows executed in the Workflow, indexed by the EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED event id
+	// Used to retrieve the child workflows from events
+	childWfMap map[int64]*WorkflowExecutionState
+	// timerMap contains all the timers executed in the Workflow, indexed by the EVENT_TYPE_TIMER_STARTED event id
+	// Used to retrieve the timers from events
+	timerMap map[int64]*TimerExecutionState
+
+	// Non-successful closed states
+	Failure       *failure.Failure
+	Termination   *history.WorkflowExecutionTerminatedEventAttributes
+	CancelRequest *history.WorkflowExecutionCancelRequestedEventAttributes
+	RetryState    enums.RetryState
+
+	// Timeout and retry policies
+	WorkflowExecutionTimeout *time.Duration
+	Attempt                  int32
+	MaximumAttempts          int32
+
+	// Parent Information
+	ParentWorkflowExecution *common.WorkflowExecution
+}
+
+func NewWorkflowExecutionState(wfId, runId string) *WorkflowExecutionState {
+	return &WorkflowExecutionState{
+		Execution: &common.WorkflowExecution{WorkflowId: wfId, RunId: runId},
+	}
+}
+
+func (state *WorkflowExecutionState) GetName() string {
+	return state.Type.Name
+}
+
+func (state *WorkflowExecutionState) GetAttempt() int32 {
+	return state.Attempt
+}
+
+func (state *WorkflowExecutionState) GetFailure() *failure.Failure {
+	return state.Failure
+}
+
+func (state *WorkflowExecutionState) GetRetryState() enums.RetryState {
+	return state.RetryState
+}
+
+func (state *WorkflowExecutionState) GetStartTime() *time.Time {
+	return state.StartTime
+}
+
+func (state *WorkflowExecutionState) GetDuration() *time.Duration {
+	return getDuration(state.StartTime, state.CloseTime)
+}
+
+func (state *WorkflowExecutionState) newActivity(event *history.HistoryEvent) *ActivityExecutionState {
+	if state.activityMap == nil {
+		state.activityMap = make(map[int64]*ActivityExecutionState)
+	}
+	activityState := NewActivityExecutionState()
+	activityState.Update(event)
+
+	state.activityMap[event.EventId] = activityState
+	state.ChildStates = append(state.ChildStates, activityState)
+
+	return activityState
+}
+
+func (state *WorkflowExecutionState) updateActivity(scheduledId int64, event *history.HistoryEvent) {
+	if activityState, ok := state.activityMap[scheduledId]; ok {
+		activityState.Update(event)
+	}
+}
+
+// FindChildWorkflow searches for a child workflow that matches the given WorkflowExecution. It's searched within the ChildStates list to avoid concurrent map writes.
+func (state *WorkflowExecutionState) FindChildWorkflow(execution *common.WorkflowExecution) *WorkflowExecutionState {
+	for _, child := range state.ChildStates {
+		if wf, ok := child.(*WorkflowExecutionState); ok && wf.Execution == execution {
+			return wf
+		}
+	}
+	return nil
+}
+
+func (state *WorkflowExecutionState) newChildWorkflow(event *history.HistoryEvent) *WorkflowExecutionState {
+	if state.childWfMap == nil {
+		state.childWfMap = make(map[int64]*WorkflowExecutionState)
+	}
+	attrs := event.GetStartChildWorkflowExecutionInitiatedEventAttributes()
+	childWfState := NewWorkflowExecutionState(attrs.GetWorkflowId(), "")
+	childWfState.Type = attrs.GetWorkflowType()
+
+	state.childWfMap[event.EventId] = childWfState
+	state.ChildStates = append(state.ChildStates, childWfState)
+
+	return childWfState
+}
+
+func (state *WorkflowExecutionState) newTimer(event *history.HistoryEvent) *TimerExecutionState {
+	if state.timerMap == nil {
+		state.timerMap = make(map[int64]*TimerExecutionState)
+	}
+	timerState := &TimerExecutionState{}
+	timerState.Update(event)
+
+	state.timerMap[event.EventId] = timerState
+	state.ChildStates = append(state.ChildStates, timerState)
+
+	return timerState
+}
+
+func (state *WorkflowExecutionState) updateTimer(startedId int64, event *history.HistoryEvent) {
+	if timerState, ok := state.timerMap[startedId]; ok {
+		timerState.Update(event)
+	}
+}
+
+// IsCompleted returns true when the Workflow Execution is completed in a non-failed state.
+// This is useful to know if we should fetch child workflows or fold the information.
+// For now this is when the workflow is completed, terminated or canceled.
+func (state *WorkflowExecutionState) IsCompleted() bool {
+	return state.Status == enums.WORKFLOW_EXECUTION_STATUS_COMPLETED ||
+		state.Status == enums.WORKFLOW_EXECUTION_STATUS_CANCELED ||
+		state.Status == enums.WORKFLOW_EXECUTION_STATUS_TERMINATED
+}
+
+func (state *WorkflowExecutionState) Update(event *history.HistoryEvent) {
+	if event == nil {
+		return
+	}
+
+	state.LastEventId = event.EventId
+	switch event.EventType {
+	case enums.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED:
+		// Always the first event in a workflow history
+		state.Status = enums.WORKFLOW_EXECUTION_STATUS_RUNNING
+
+		attrs := event.GetWorkflowExecutionStartedEventAttributes()
+		state.StartTime = event.EventTime
+		state.Attempt = attrs.GetAttempt()
+		state.Type = attrs.GetWorkflowType()
+
+		// Not sure if this is the right RunId
+		state.Execution.RunId = attrs.OriginalExecutionRunId
+		state.ParentWorkflowExecution = attrs.ParentWorkflowExecution
+
+		// Cleanup the failure/cancel request
+		state.Failure = nil
+		state.CancelRequest = nil
+		state.Termination = nil
+
+		// Get timeout and max retry info
+		state.WorkflowExecutionTimeout = attrs.WorkflowExecutionTimeout
+		if attrs.RetryPolicy != nil {
+			state.MaximumAttempts = attrs.RetryPolicy.MaximumAttempts
+		} else {
+			state.MaximumAttempts = 0
+		}
+
+	case enums.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
+		state.Status = enums.WORKFLOW_EXECUTION_STATUS_COMPLETED
+		state.CloseTime = event.EventTime
+
+	case enums.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
+		state.Status = enums.WORKFLOW_EXECUTION_STATUS_FAILED
+
+		attrs := event.GetWorkflowExecutionFailedEventAttributes()
+		state.Failure = attrs.GetFailure()
+		state.RetryState = attrs.GetRetryState()
+		state.CloseTime = event.EventTime
+
+	case enums.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
+		state.Status = enums.WORKFLOW_EXECUTION_STATUS_TERMINATED
+		state.Termination = event.GetWorkflowExecutionTerminatedEventAttributes()
+		state.CloseTime = event.EventTime
+
+	case enums.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
+		state.CancelRequest = event.GetWorkflowExecutionCancelRequestedEventAttributes()
+
+	case enums.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
+		state.Status = enums.WORKFLOW_EXECUTION_STATUS_CANCELED
+		state.CloseTime = event.EventTime
+
+	case enums.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW:
+		state.Status = enums.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
+		state.CloseTime = event.EventTime
+
+	case enums.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
+		attrs := event.GetWorkflowExecutionTimedOutEventAttributes()
+		state.Status = enums.WORKFLOW_EXECUTION_STATUS_TIMED_OUT
+		state.CloseTime = event.EventTime
+		state.RetryState = attrs.GetRetryState()
+
+	// ACTIVITY EVENTS
+	case enums.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
+		// First activity event
+		state.newActivity(event)
+	case enums.EVENT_TYPE_ACTIVITY_TASK_STARTED:
+		attrs := event.GetActivityTaskStartedEventAttributes()
+		state.updateActivity(attrs.ScheduledEventId, event)
+	case enums.EVENT_TYPE_ACTIVITY_TASK_FAILED:
+		attrs := event.GetActivityTaskFailedEventAttributes()
+		state.updateActivity(attrs.ScheduledEventId, event)
+	case enums.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
+		attrs := event.GetActivityTaskCompletedEventAttributes()
+		state.updateActivity(attrs.ScheduledEventId, event)
+	case enums.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED:
+		attrs := event.GetActivityTaskCancelRequestedEventAttributes()
+		state.updateActivity(attrs.ScheduledEventId, event)
+	case enums.EVENT_TYPE_ACTIVITY_TASK_CANCELED:
+		attrs := event.GetActivityTaskCanceledEventAttributes()
+		state.updateActivity(attrs.ScheduledEventId, event)
+	case enums.EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT:
+		attrs := event.GetActivityTaskTimedOutEventAttributes()
+		state.updateActivity(attrs.ScheduledEventId, event)
+
+	// CHILD WORKFLOW EVENTS
+	case enums.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED:
+		// First child workflow
+		state.newChildWorkflow(event)
+	case enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED:
+		attrs := event.GetChildWorkflowExecutionStartedEventAttributes()
+		if child, ok := state.childWfMap[attrs.InitiatedEventId]; ok {
+			child.Status = enums.WORKFLOW_EXECUTION_STATUS_RUNNING
+			child.Execution = attrs.GetWorkflowExecution()
+			if child.StartTime == nil {
+				child.StartTime = event.EventTime
+			}
+		}
+	case enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED:
+		attrs := event.GetChildWorkflowExecutionCompletedEventAttributes()
+		if child, ok := state.childWfMap[attrs.InitiatedEventId]; ok {
+			child.Status = enums.WORKFLOW_EXECUTION_STATUS_COMPLETED
+			if child.CloseTime == nil {
+				child.CloseTime = event.EventTime
+			}
+		}
+	case enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED:
+		attrs := event.GetChildWorkflowExecutionFailedEventAttributes()
+		if child, ok := state.childWfMap[attrs.InitiatedEventId]; ok {
+			child.Status = enums.WORKFLOW_EXECUTION_STATUS_FAILED
+			child.Failure = attrs.GetFailure()
+			child.RetryState = attrs.GetRetryState()
+			if child.CloseTime == nil {
+				child.CloseTime = event.EventTime
+			}
+		}
+	case enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TERMINATED:
+		attrs := event.GetChildWorkflowExecutionTerminatedEventAttributes()
+		// We don't have termination reason from this event :(
+		if child, ok := state.childWfMap[attrs.InitiatedEventId]; ok {
+			child.Status = enums.WORKFLOW_EXECUTION_STATUS_TERMINATED
+			if child.CloseTime == nil {
+				child.CloseTime = event.EventTime
+			}
+		}
+	case enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED:
+		attrs := event.GetChildWorkflowExecutionCanceledEventAttributes()
+		if child, ok := state.childWfMap[attrs.InitiatedEventId]; ok {
+			child.Status = enums.WORKFLOW_EXECUTION_STATUS_CANCELED
+			if child.CloseTime == nil {
+				child.CloseTime = event.EventTime
+			}
+		}
+	case enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT:
+		attrs := event.GetChildWorkflowExecutionTimedOutEventAttributes()
+		if child, ok := state.childWfMap[attrs.InitiatedEventId]; ok {
+			child.Status = enums.WORKFLOW_EXECUTION_STATUS_TIMED_OUT
+			if child.CloseTime == nil {
+				child.CloseTime = event.EventTime
+			}
+		}
+
+	// TIMER EVENTS
+	case enums.EVENT_TYPE_TIMER_STARTED:
+		state.newTimer(event)
+	case enums.EVENT_TYPE_TIMER_FIRED:
+		startedId := event.GetTimerFiredEventAttributes().GetStartedEventId()
+		state.updateTimer(startedId, event)
+	case enums.EVENT_TYPE_TIMER_CANCELED:
+		startedId := event.GetTimerCanceledEventAttributes().GetStartedEventId()
+		state.updateTimer(startedId, event)
+	}
+}
+
+// GetNumberOfEvents returns a count of the number of events processed and the total for a workflow execution.
+// This method iteratively sums the LastEventId (the sequential id of the last event processed) and the HistoryLength for all child workflows
+func (state *WorkflowExecutionState) GetNumberOfEvents() (int64, int64) {
+	var current, total int64
+	if state.ChildStates == nil {
+		return 0, 0
+	}
+	for _, child := range state.ChildStates {
+		if childWf, ok := child.(*WorkflowExecutionState); ok {
+			c, t := childWf.GetNumberOfEvents()
+			current += c
+			total += t
+		}
+	}
+	return current + state.LastEventId, total + state.HistoryLength
+}
+
+// ActivityExecutionStatus is the Status of an ActivityExecution, analogous to enums.WorkflowExecutionStatus.
+type ActivityExecutionStatus int32
+
+var (
+	ACTIVITY_EXECUTION_STATUS_UNSPECIFIED      ActivityExecutionStatus = 0
+	ACTIVITY_EXECUTION_STATUS_SCHEDULED        ActivityExecutionStatus = 1
+	ACTIVITY_EXECUTION_STATUS_RUNNING          ActivityExecutionStatus = 2
+	ACTIVITY_EXECUTION_STATUS_COMPLETED        ActivityExecutionStatus = 3
+	ACTIVITY_EXECUTION_STATUS_FAILED           ActivityExecutionStatus = 4
+	ACTIVITY_EXECUTION_STATUS_TIMED_OUT        ActivityExecutionStatus = 5
+	ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED ActivityExecutionStatus = 6
+	ACTIVITY_EXECUTION_STATUS_CANCELED         ActivityExecutionStatus = 7
+)
+
+type ActivityExecutionState struct {
+	ActivityId string
+	Status     ActivityExecutionStatus
+	Type       *common.ActivityType
+	Attempt    int32
+	Failure    *failure.Failure
+	RetryState enums.RetryState
+
+	StartTime *time.Time
+	CloseTime *time.Time
+}
+
+func NewActivityExecutionState() *ActivityExecutionState {
+	return &ActivityExecutionState{}
+}
+
+func (state *ActivityExecutionState) GetName() string {
+	return state.Type.Name
+}
+
+func (state *ActivityExecutionState) GetAttempt() int32 {
+	return state.Attempt
+}
+
+func (state *ActivityExecutionState) GetFailure() *failure.Failure {
+	return state.Failure
+}
+
+func (state *ActivityExecutionState) GetRetryState() enums.RetryState {
+	return state.RetryState
+}
+
+func (state *ActivityExecutionState) GetStartTime() *time.Time {
+	return state.StartTime
+}
+
+func (state *ActivityExecutionState) GetDuration() *time.Duration {
+	return getDuration(state.StartTime, state.CloseTime)
+}
+
+func (state *ActivityExecutionState) Update(event *history.HistoryEvent) {
+	switch event.EventType {
+	case enums.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
+		state.Status = ACTIVITY_EXECUTION_STATUS_SCHEDULED
+
+		attrs := event.GetActivityTaskScheduledEventAttributes()
+		state.ActivityId = attrs.GetActivityId()
+		state.Type = attrs.GetActivityType()
+
+	case enums.EVENT_TYPE_ACTIVITY_TASK_STARTED:
+		state.Status = ACTIVITY_EXECUTION_STATUS_RUNNING
+
+		attrs := event.GetActivityTaskStartedEventAttributes()
+		state.Attempt = attrs.GetAttempt()
+
+		// This is the best guess we have for when the activity was started
+		state.StartTime = event.EventTime
+
+		// Clear failures
+		state.Failure = nil
+
+	case enums.EVENT_TYPE_ACTIVITY_TASK_FAILED:
+		state.Status = ACTIVITY_EXECUTION_STATUS_FAILED
+
+		attrs := event.GetActivityTaskFailedEventAttributes()
+		state.Failure = attrs.GetFailure()
+		state.RetryState = attrs.GetRetryState()
+		state.CloseTime = event.EventTime
+
+	case enums.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
+		state.Status = ACTIVITY_EXECUTION_STATUS_COMPLETED
+		state.CloseTime = event.EventTime
+
+	case enums.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED:
+		state.Status = ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED
+
+	case enums.EVENT_TYPE_ACTIVITY_TASK_CANCELED:
+		state.Status = ACTIVITY_EXECUTION_STATUS_CANCELED
+		state.CloseTime = event.EventTime
+
+	case enums.EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT:
+		state.Status = ACTIVITY_EXECUTION_STATUS_TIMED_OUT
+
+		attrs := event.GetActivityTaskTimedOutEventAttributes()
+		state.Failure = attrs.GetFailure()
+		state.RetryState = attrs.GetRetryState()
+		state.CloseTime = event.EventTime
+	}
+}
+
+// TimerExecutionState contains information about a Timer as an execution.
+type TimerExecutionState struct {
+	TimerId            string
+	Name               string
+	StartToFireTimeout *time.Duration
+	Status             TimerExecutionStatus
+	StartTime          *time.Time
+	CloseTime          *time.Time
+}
+
+// TimerExecutionStatus is the Status of a TimerExecution, analogous to enums.WorkflowExecutionStatus.
+type TimerExecutionStatus int32
+
+var (
+	TIMER_STATUS_WAITING  TimerExecutionStatus = 0
+	TIMER_STATUS_FIRED    TimerExecutionStatus = 1
+	TIMER_STATUS_CANCELED TimerExecutionStatus = 2
+)
+
+func (t *TimerExecutionState) Update(event *history.HistoryEvent) {
+	switch event.EventType {
+	case enums.EVENT_TYPE_TIMER_STARTED:
+		attrs := event.GetTimerStartedEventAttributes()
+
+		t.TimerId = attrs.TimerId
+		if attrs.TimerId != strconv.FormatInt(event.EventId, 10) {
+			// If the user has set a custom id, we can use it for the name
+			t.Name = attrs.TimerId
+		}
+		t.StartToFireTimeout = attrs.StartToFireTimeout
+		t.Status = TIMER_STATUS_WAITING
+		t.StartTime = event.EventTime
+	case enums.EVENT_TYPE_TIMER_FIRED:
+		t.Status = TIMER_STATUS_FIRED
+		t.CloseTime = event.EventTime
+	case enums.EVENT_TYPE_TIMER_CANCELED:
+		t.Status = TIMER_STATUS_CANCELED
+		t.CloseTime = event.EventTime
+	}
+}
+
+func (t *TimerExecutionState) GetName() string {
+	timerDuration := t.StartToFireTimeout.String()
+	if t.Name == "" {
+		return fmt.Sprintf("Timer (%s)", timerDuration)
+	} else {
+		return fmt.Sprintf("%s timer (%s)", t.Name, timerDuration)
+	}
+}
+
+func (t *TimerExecutionState) GetAttempt() int32 {
+	return 1
+}
+
+func (t *TimerExecutionState) GetFailure() *failure.Failure {
+	return nil
+}
+
+func (t *TimerExecutionState) GetRetryState() enums.RetryState {
+	return enums.RETRY_STATE_UNSPECIFIED
+}
+
+func (t *TimerExecutionState) GetDuration() *time.Duration {
+	return getDuration(t.StartTime, t.CloseTime)
+}
+
+func (t *TimerExecutionState) GetStartTime() *time.Time {
+	return t.StartTime
+}
+
+// Utilities
+// getDuration converts a start and completed time to a duration.
+func getDuration(started, completed *time.Time) *time.Duration {
+	if started == nil || completed == nil {
+		return nil
+	}
+	duration := completed.Sub(*started)
+	return &duration
+}

--- a/cli/trace/execution_state.go
+++ b/cli/trace/execution_state.go
@@ -199,8 +199,6 @@ func (state *WorkflowExecutionState) Update(event *history.HistoryEvent) {
 		state.Attempt = attrs.GetAttempt()
 		state.Type = attrs.GetWorkflowType()
 
-		// Not sure if this is the right RunId
-		state.Execution.RunId = attrs.OriginalExecutionRunId
 		state.ParentWorkflowExecution = attrs.ParentWorkflowExecution
 
 		// Cleanup the failure/cancel request

--- a/cli/trace/execution_state_test.go
+++ b/cli/trace/execution_state_test.go
@@ -17,9 +17,8 @@ var events = map[string]*history.HistoryEvent{
 		EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
 		Attributes: &history.HistoryEvent_WorkflowExecutionStartedEventAttributes{
 			WorkflowExecutionStartedEventAttributes: &history.WorkflowExecutionStartedEventAttributes{
-				WorkflowType:           &common.WorkflowType{Name: "foo"},
-				Attempt:                1,
-				OriginalExecutionRunId: "bar",
+				WorkflowType: &common.WorkflowType{Name: "foo"},
+				Attempt:      1,
 			},
 		},
 	},
@@ -217,9 +216,8 @@ var events = map[string]*history.HistoryEvent{
 		EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
 		Attributes: &history.HistoryEvent_WorkflowExecutionStartedEventAttributes{
 			WorkflowExecutionStartedEventAttributes: &history.WorkflowExecutionStartedEventAttributes{
-				WorkflowType:           &common.WorkflowType{Name: "baz"},
-				Attempt:                1,
-				OriginalExecutionRunId: "childRunId",
+				WorkflowType: &common.WorkflowType{Name: "baz"},
+				Attempt:      1,
 			},
 		},
 	},
@@ -274,7 +272,7 @@ func TestExecutionState_UpdateWorkflow(t *testing.T) {
 			events: []*history.HistoryEvent{events["started"]},
 			expectedState: &WorkflowExecutionState{
 				LastEventId: 1,
-				Execution:   &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Execution:   &common.WorkflowExecution{WorkflowId: "foo"},
 				Type:        &common.WorkflowType{Name: "foo"},
 				Status:      enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
 				Attempt:     1,
@@ -284,7 +282,7 @@ func TestExecutionState_UpdateWorkflow(t *testing.T) {
 			events: []*history.HistoryEvent{events["started"], events["completed"]},
 			expectedState: &WorkflowExecutionState{
 				LastEventId: 100,
-				Execution:   &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Execution:   &common.WorkflowExecution{WorkflowId: "foo"},
 				Type:        &common.WorkflowType{Name: "foo"},
 				Status:      enums.WORKFLOW_EXECUTION_STATUS_COMPLETED,
 				Attempt:     1,
@@ -294,7 +292,7 @@ func TestExecutionState_UpdateWorkflow(t *testing.T) {
 			events: []*history.HistoryEvent{events["started"], events["failed"]},
 			expectedState: &WorkflowExecutionState{
 				LastEventId: 89,
-				Execution:   &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Execution:   &common.WorkflowExecution{WorkflowId: "foo"},
 				Type:        &common.WorkflowType{Name: "foo"},
 				Status:      enums.WORKFLOW_EXECUTION_STATUS_FAILED,
 				Attempt:     1,
@@ -306,7 +304,7 @@ func TestExecutionState_UpdateWorkflow(t *testing.T) {
 			events: []*history.HistoryEvent{events["started"], events["cancel requested"]},
 			expectedState: &WorkflowExecutionState{
 				LastEventId: 89,
-				Execution:   &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Execution:   &common.WorkflowExecution{WorkflowId: "foo"},
 				Type:        &common.WorkflowType{Name: "foo"},
 				Status:      enums.WORKFLOW_EXECUTION_STATUS_RUNNING, // There's no cancel requested status in Temporal's enums
 				CancelRequest: &history.WorkflowExecutionCancelRequestedEventAttributes{
@@ -320,7 +318,7 @@ func TestExecutionState_UpdateWorkflow(t *testing.T) {
 			events: []*history.HistoryEvent{events["started"], events["cancel requested"], events["canceled"]},
 			expectedState: &WorkflowExecutionState{
 				LastEventId: 90,
-				Execution:   &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Execution:   &common.WorkflowExecution{WorkflowId: "foo"},
 				Type:        &common.WorkflowType{Name: "foo"},
 				Status:      enums.WORKFLOW_EXECUTION_STATUS_CANCELED,
 				CancelRequest: &history.WorkflowExecutionCancelRequestedEventAttributes{
@@ -580,6 +578,7 @@ func TestExecutionState_UpdateTimers(t *testing.T) {
 			events: []*history.HistoryEvent{events["started"], events["timer started"]},
 			expectedChilds: []ExecutionState{
 				&TimerExecutionState{
+					Name:               "Timer (1h0m0s)",
 					TimerId:            "20",
 					StartToFireTimeout: NewDuration(time.Hour),
 					Status:             TIMER_STATUS_WAITING,
@@ -590,6 +589,7 @@ func TestExecutionState_UpdateTimers(t *testing.T) {
 			events: []*history.HistoryEvent{events["started"], events["timer started"], events["timer fired"]},
 			expectedChilds: []ExecutionState{
 				&TimerExecutionState{
+					Name:               "Timer (1h0m0s)",
 					TimerId:            "20",
 					StartToFireTimeout: NewDuration(time.Hour),
 					Status:             TIMER_STATUS_FIRED,
@@ -600,6 +600,7 @@ func TestExecutionState_UpdateTimers(t *testing.T) {
 			events: []*history.HistoryEvent{events["started"], events["timer started"], events["timer canceled"]},
 			expectedChilds: []ExecutionState{
 				&TimerExecutionState{
+					Name:               "Timer (1h0m0s)",
 					TimerId:            "20",
 					StartToFireTimeout: NewDuration(time.Hour),
 					Status:             TIMER_STATUS_CANCELED,
@@ -640,7 +641,6 @@ func TestExecutionState_TimerExecutionStateImplementation(t *testing.T) {
 				StartTime:          NewTime(0),
 			},
 			Expected: expectations{
-				Name:       "Timer (1h0m0s)",
 				Attempt:    1,
 				Failure:    nil,
 				RetryState: 0,
@@ -657,7 +657,6 @@ func TestExecutionState_TimerExecutionStateImplementation(t *testing.T) {
 				CloseTime:          NewTime(time.Hour),
 			},
 			Expected: expectations{
-				Name:       "Timer (1h0m0s)",
 				Attempt:    1,
 				Failure:    nil,
 				RetryState: 0,
@@ -674,7 +673,6 @@ func TestExecutionState_TimerExecutionStateImplementation(t *testing.T) {
 				CloseTime:          NewTime(30 * time.Minute),
 			},
 			Expected: expectations{
-				Name:       "Timer (1h0m0s)",
 				Attempt:    1,
 				Failure:    nil,
 				RetryState: 0,
@@ -691,7 +689,7 @@ func TestExecutionState_TimerExecutionStateImplementation(t *testing.T) {
 				StartTime:          NewTime(0),
 			},
 			Expected: expectations{
-				Name:       "TestTimer timer (1h0m0s)",
+				Name:       "TestTimer",
 				Attempt:    1,
 				Failure:    nil,
 				RetryState: 0,

--- a/cli/trace/execution_state_test.go
+++ b/cli/trace/execution_state_test.go
@@ -1,0 +1,714 @@
+package sundial
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/failure/v1"
+	"go.temporal.io/api/history/v1"
+	"testing"
+	"time"
+)
+
+var events = map[string]*history.HistoryEvent{
+	"started": {
+		EventId:   1,
+		EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+		Attributes: &history.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+			WorkflowExecutionStartedEventAttributes: &history.WorkflowExecutionStartedEventAttributes{
+				WorkflowType:           &common.WorkflowType{Name: "foo"},
+				Attempt:                1,
+				OriginalExecutionRunId: "bar",
+			},
+		},
+	},
+	"completed": {
+		EventId:   100,
+		EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
+		Attributes: &history.HistoryEvent_WorkflowExecutionCompletedEventAttributes{
+			WorkflowExecutionCompletedEventAttributes: &history.WorkflowExecutionCompletedEventAttributes{
+				WorkflowTaskCompletedEventId: 120,
+				NewExecutionRunId:            "foobar",
+			},
+		},
+	},
+	"failed": {
+		EventId:   89,
+		EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED,
+		Attributes: &history.HistoryEvent_WorkflowExecutionFailedEventAttributes{
+			WorkflowExecutionFailedEventAttributes: &history.WorkflowExecutionFailedEventAttributes{
+				Failure: &failure.Failure{
+					Message: "Totally expected workflow failure",
+				},
+				RetryState:                   enums.RETRY_STATE_NON_RETRYABLE_FAILURE,
+				WorkflowTaskCompletedEventId: 120,
+				NewExecutionRunId:            "foobar",
+			},
+		},
+	},
+	"cancel requested": {
+		EventId:   89,
+		EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED,
+		Attributes: &history.HistoryEvent_WorkflowExecutionCancelRequestedEventAttributes{
+			WorkflowExecutionCancelRequestedEventAttributes: &history.WorkflowExecutionCancelRequestedEventAttributes{
+				Cause:    "foobar",
+				Identity: "unit test",
+			},
+		},
+	},
+	"canceled": {
+		EventId:   90,
+		EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED,
+		Attributes: &history.HistoryEvent_WorkflowExecutionCanceledEventAttributes{
+			WorkflowExecutionCanceledEventAttributes: &history.WorkflowExecutionCanceledEventAttributes{},
+		},
+	},
+	"activity scheduled": {
+		EventId:   10,
+		EventType: enums.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
+		Attributes: &history.HistoryEvent_ActivityTaskScheduledEventAttributes{
+			ActivityTaskScheduledEventAttributes: &history.ActivityTaskScheduledEventAttributes{
+				ActivityId:   "abc",
+				ActivityType: &common.ActivityType{Name: "Mr ActivityFace"},
+			},
+		},
+	},
+	"activity started": {
+		EventId:   13,
+		EventType: enums.EVENT_TYPE_ACTIVITY_TASK_STARTED,
+		Attributes: &history.HistoryEvent_ActivityTaskStartedEventAttributes{
+			ActivityTaskStartedEventAttributes: &history.ActivityTaskStartedEventAttributes{
+				ScheduledEventId: 10,
+				Identity:         "worker-baz",
+				Attempt:          1,
+			},
+		},
+	},
+	"activity failed": {
+		EventId:   20, // same Id as completed for testing purposes
+		EventType: enums.EVENT_TYPE_ACTIVITY_TASK_FAILED,
+		Attributes: &history.HistoryEvent_ActivityTaskFailedEventAttributes{
+			ActivityTaskFailedEventAttributes: &history.ActivityTaskFailedEventAttributes{
+				ScheduledEventId: 10,
+				StartedEventId:   13,
+				Identity:         "worker-baz",
+				Failure:          &failure.Failure{Message: "I was a test"},
+			},
+		},
+	},
+	"activity completed": {
+		EventId:   20, // same Id as failed for testing purposes
+		EventType: enums.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,
+		Attributes: &history.HistoryEvent_ActivityTaskCompletedEventAttributes{
+			ActivityTaskCompletedEventAttributes: &history.ActivityTaskCompletedEventAttributes{
+				ScheduledEventId: 10,
+				StartedEventId:   13,
+				Identity:         "worker-baz",
+			},
+		},
+	},
+	"activity cancel requested": {
+		EventId:   20, // same Id as failed for testing purposes
+		EventType: enums.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED,
+		Attributes: &history.HistoryEvent_ActivityTaskCancelRequestedEventAttributes{
+			ActivityTaskCancelRequestedEventAttributes: &history.ActivityTaskCancelRequestedEventAttributes{
+				ScheduledEventId: 10,
+			},
+		},
+	},
+	"activity canceled": {
+		EventId:   21,
+		EventType: enums.EVENT_TYPE_ACTIVITY_TASK_CANCELED,
+		Attributes: &history.HistoryEvent_ActivityTaskCanceledEventAttributes{
+			ActivityTaskCanceledEventAttributes: &history.ActivityTaskCanceledEventAttributes{
+				ScheduledEventId:             10,
+				LatestCancelRequestedEventId: 20,
+				Identity:                     "unit test",
+			},
+		},
+	},
+	"second activity scheduled": {
+		EventId:   30,
+		EventType: enums.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
+		Attributes: &history.HistoryEvent_ActivityTaskScheduledEventAttributes{
+			ActivityTaskScheduledEventAttributes: &history.ActivityTaskScheduledEventAttributes{
+				ActivityId:   "def",
+				ActivityType: &common.ActivityType{Name: "Hyperactivity"},
+			},
+		},
+	},
+	"child workflow initiated": {
+		EventId:   50,
+		EventType: enums.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
+		Attributes: &history.HistoryEvent_StartChildWorkflowExecutionInitiatedEventAttributes{
+			StartChildWorkflowExecutionInitiatedEventAttributes: &history.StartChildWorkflowExecutionInitiatedEventAttributes{
+				Namespace:    "default",
+				WorkflowId:   "childWfId",
+				WorkflowType: &common.WorkflowType{Name: "baz"},
+			},
+		},
+	},
+	"child workflow started": {
+		EventId:   52,
+		EventType: enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED,
+		Attributes: &history.HistoryEvent_ChildWorkflowExecutionStartedEventAttributes{
+			ChildWorkflowExecutionStartedEventAttributes: &history.ChildWorkflowExecutionStartedEventAttributes{
+				Namespace:        "default",
+				InitiatedEventId: 50,
+				WorkflowExecution: &common.WorkflowExecution{
+					WorkflowId: "childWfId", RunId: "childRunId",
+				},
+				WorkflowType: &common.WorkflowType{Name: "baz"},
+			},
+		},
+	},
+	"child workflow completed": {
+		EventId:   60,
+		EventType: enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED,
+		Attributes: &history.HistoryEvent_ChildWorkflowExecutionCompletedEventAttributes{
+			ChildWorkflowExecutionCompletedEventAttributes: &history.ChildWorkflowExecutionCompletedEventAttributes{
+				Namespace: "default",
+				WorkflowExecution: &common.WorkflowExecution{
+					WorkflowId: "childWfId", RunId: "childRunId",
+				},
+				WorkflowType:     &common.WorkflowType{Name: "baz"},
+				InitiatedEventId: 50,
+				StartedEventId:   52,
+			},
+		},
+	},
+	"child workflow failed": {
+		EventId:   55,
+		EventType: enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED,
+		Attributes: &history.HistoryEvent_ChildWorkflowExecutionFailedEventAttributes{
+			ChildWorkflowExecutionFailedEventAttributes: &history.ChildWorkflowExecutionFailedEventAttributes{
+				Failure: &failure.Failure{
+					Message: "This child failed us",
+				},
+				RetryState: enums.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
+				Namespace:  "default",
+				WorkflowExecution: &common.WorkflowExecution{
+					WorkflowId: "childWfId", RunId: "childRunId",
+				},
+				WorkflowType:     &common.WorkflowType{Name: "baz"},
+				InitiatedEventId: 50,
+				StartedEventId:   52,
+			},
+		},
+	},
+	"child workflow canceled": {
+		EventId:   55,
+		EventType: enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED,
+		Attributes: &history.HistoryEvent_ChildWorkflowExecutionCanceledEventAttributes{
+			ChildWorkflowExecutionCanceledEventAttributes: &history.ChildWorkflowExecutionCanceledEventAttributes{
+				Namespace: "default",
+				WorkflowExecution: &common.WorkflowExecution{
+					WorkflowId: "childWfId", RunId: "childRunId",
+				},
+				WorkflowType:     &common.WorkflowType{Name: "baz"},
+				InitiatedEventId: 50,
+				StartedEventId:   52,
+			},
+		},
+	},
+	"workflow started child": {
+		EventId:   1,
+		EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+		Attributes: &history.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+			WorkflowExecutionStartedEventAttributes: &history.WorkflowExecutionStartedEventAttributes{
+				WorkflowType:           &common.WorkflowType{Name: "baz"},
+				Attempt:                1,
+				OriginalExecutionRunId: "childRunId",
+			},
+		},
+	},
+	"timer started": {
+		EventId:   20,
+		EventType: enums.EVENT_TYPE_TIMER_STARTED,
+		Attributes: &history.HistoryEvent_TimerStartedEventAttributes{
+			TimerStartedEventAttributes: &history.TimerStartedEventAttributes{
+				TimerId:            "20", // If TimerId is not set it'll be the same as EventId
+				StartToFireTimeout: NewDuration(time.Hour),
+			},
+		},
+	},
+	"timer fired": {
+		EventId:   21,
+		EventType: enums.EVENT_TYPE_TIMER_FIRED,
+		Attributes: &history.HistoryEvent_TimerFiredEventAttributes{
+			TimerFiredEventAttributes: &history.TimerFiredEventAttributes{
+				TimerId:        "20",
+				StartedEventId: 20,
+			},
+		},
+	},
+	"timer canceled": {
+		EventId:   21,
+		EventType: enums.EVENT_TYPE_TIMER_CANCELED,
+		Attributes: &history.HistoryEvent_TimerCanceledEventAttributes{
+			TimerCanceledEventAttributes: &history.TimerCanceledEventAttributes{
+				TimerId:        "20",
+				StartedEventId: 20,
+				Identity:       "test",
+			},
+		},
+	},
+}
+
+func NewDuration(d time.Duration) *time.Duration {
+	return &d
+}
+
+func NewTime(d time.Duration) *time.Time {
+	t := time.Time{}.Add(d)
+	return &t
+}
+
+func TestExecutionState_UpdateWorkflow(t *testing.T) {
+	tests := map[string]struct {
+		events        []*history.HistoryEvent
+		expectedState *WorkflowExecutionState
+	}{
+		"workflow started": {
+			events: []*history.HistoryEvent{events["started"]},
+			expectedState: &WorkflowExecutionState{
+				LastEventId: 1,
+				Execution:   &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Type:        &common.WorkflowType{Name: "foo"},
+				Status:      enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				Attempt:     1,
+			},
+		},
+		"workflow completed": {
+			events: []*history.HistoryEvent{events["started"], events["completed"]},
+			expectedState: &WorkflowExecutionState{
+				LastEventId: 100,
+				Execution:   &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Type:        &common.WorkflowType{Name: "foo"},
+				Status:      enums.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+				Attempt:     1,
+			},
+		},
+		"workflow failed": {
+			events: []*history.HistoryEvent{events["started"], events["failed"]},
+			expectedState: &WorkflowExecutionState{
+				LastEventId: 89,
+				Execution:   &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Type:        &common.WorkflowType{Name: "foo"},
+				Status:      enums.WORKFLOW_EXECUTION_STATUS_FAILED,
+				Attempt:     1,
+				Failure:     &failure.Failure{Message: "Totally expected workflow failure"},
+				RetryState:  enums.RETRY_STATE_NON_RETRYABLE_FAILURE,
+			},
+		},
+		"workflow cancel requested": {
+			events: []*history.HistoryEvent{events["started"], events["cancel requested"]},
+			expectedState: &WorkflowExecutionState{
+				LastEventId: 89,
+				Execution:   &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Type:        &common.WorkflowType{Name: "foo"},
+				Status:      enums.WORKFLOW_EXECUTION_STATUS_RUNNING, // There's no cancel requested status in Temporal's enums
+				CancelRequest: &history.WorkflowExecutionCancelRequestedEventAttributes{
+					Cause:    "foobar",
+					Identity: "unit test",
+				},
+				Attempt: 1,
+			},
+		},
+		"workflow canceled": {
+			events: []*history.HistoryEvent{events["started"], events["cancel requested"], events["canceled"]},
+			expectedState: &WorkflowExecutionState{
+				LastEventId: 90,
+				Execution:   &common.WorkflowExecution{WorkflowId: "foo", RunId: "bar"},
+				Type:        &common.WorkflowType{Name: "foo"},
+				Status:      enums.WORKFLOW_EXECUTION_STATUS_CANCELED,
+				CancelRequest: &history.WorkflowExecutionCancelRequestedEventAttributes{
+					Cause:    "foobar",
+					Identity: "unit test",
+				},
+				Attempt: 1,
+			},
+		},
+		// TODO: Add terminated and canceled events
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			state := NewWorkflowExecutionState("foo", "")
+			for _, event := range tt.events {
+				state.Update(event)
+			}
+			assert.Equal(t, tt.expectedState, state)
+		})
+	}
+}
+
+func TestExecutionState_UpdateActivities(t *testing.T) {
+	tests := map[string]struct {
+		events         []*history.HistoryEvent
+		expectedChilds []ExecutionState
+	}{
+		"activity scheduled": {
+			events: []*history.HistoryEvent{events["started"], events["activity scheduled"]},
+			expectedChilds: []ExecutionState{
+				&ActivityExecutionState{
+					ActivityId: "abc",
+					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
+					Status:     ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+				},
+			},
+		},
+		"activity started": {
+			events: []*history.HistoryEvent{
+				events["started"],
+				events["activity scheduled"],
+				events["activity started"],
+			},
+			expectedChilds: []ExecutionState{
+				&ActivityExecutionState{
+					ActivityId: "abc",
+					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
+					Status:     ACTIVITY_EXECUTION_STATUS_RUNNING,
+					Attempt:    1,
+				},
+			},
+		},
+		"activity failed": {
+			events: []*history.HistoryEvent{
+				events["started"],
+				events["activity scheduled"],
+				events["activity started"],
+				events["activity failed"],
+			},
+			expectedChilds: []ExecutionState{
+				&ActivityExecutionState{
+					ActivityId: "abc",
+					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
+					Status:     ACTIVITY_EXECUTION_STATUS_FAILED,
+					Attempt:    1,
+					Failure:    &failure.Failure{Message: "I was a test"},
+				},
+			},
+		},
+		"activity completed": {
+			events: []*history.HistoryEvent{
+				events["started"],
+				events["activity scheduled"],
+				events["activity started"],
+				events["activity completed"],
+			},
+			expectedChilds: []ExecutionState{
+				&ActivityExecutionState{
+					ActivityId: "abc",
+					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
+					Status:     ACTIVITY_EXECUTION_STATUS_COMPLETED,
+					Attempt:    1,
+				},
+			},
+		},
+		"second activity scheduled": {
+			events: []*history.HistoryEvent{
+				events["started"],
+				events["activity scheduled"],
+				events["second activity scheduled"],
+				events["activity started"],
+			},
+			expectedChilds: []ExecutionState{
+				&ActivityExecutionState{
+					ActivityId: "abc",
+					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
+					Status:     ACTIVITY_EXECUTION_STATUS_RUNNING,
+					Attempt:    1,
+				},
+				&ActivityExecutionState{
+					ActivityId: "def",
+					Type:       &common.ActivityType{Name: "Hyperactivity"},
+					Status:     ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+				},
+			},
+		},
+		"activity cancel requested": {
+			events: []*history.HistoryEvent{
+				events["started"],
+				events["activity scheduled"],
+				events["activity started"],
+				events["activity cancel requested"],
+			},
+			expectedChilds: []ExecutionState{
+				&ActivityExecutionState{
+					ActivityId: "abc",
+					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
+					Status:     ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED,
+					Attempt:    1,
+				},
+			},
+		},
+		"activity canceled": {
+			events: []*history.HistoryEvent{
+				events["started"],
+				events["activity scheduled"],
+				events["activity started"],
+				events["activity cancel requested"],
+				events["activity canceled"],
+			},
+			expectedChilds: []ExecutionState{
+				&ActivityExecutionState{
+					ActivityId: "abc",
+					Type:       &common.ActivityType{Name: "Mr ActivityFace"},
+					Status:     ACTIVITY_EXECUTION_STATUS_CANCELED,
+					Attempt:    1,
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			state := NewWorkflowExecutionState("foo", "")
+			for _, event := range tt.events {
+				state.Update(event)
+			}
+			assert.Equal(t, tt.expectedChilds, state.ChildStates)
+		})
+	}
+}
+
+func TestExecutionState_UpdateChildWorkflows(t *testing.T) {
+	tests := map[string]struct {
+		events         []*history.HistoryEvent
+		expectedChilds []ExecutionState
+	}{
+		"child workflow initiated": {
+			events: []*history.HistoryEvent{events["started"], events["child workflow initiated"]},
+			expectedChilds: []ExecutionState{
+				&WorkflowExecutionState{
+					Type: &common.WorkflowType{Name: "baz"},
+					Execution: &common.WorkflowExecution{
+						WorkflowId: "childWfId", RunId: "",
+					},
+				},
+			},
+		},
+		"child workflow started": {
+			events: []*history.HistoryEvent{
+				events["started"],
+				events["child workflow initiated"],
+				events["child workflow started"],
+			},
+			expectedChilds: []ExecutionState{
+				&WorkflowExecutionState{
+					Type:   &common.WorkflowType{Name: "baz"},
+					Status: enums.WORKFLOW_EXECUTION_STATUS_RUNNING,
+					Execution: &common.WorkflowExecution{
+						WorkflowId: "childWfId", RunId: "childRunId",
+					},
+				},
+			},
+		},
+		"child workflow completed": {
+			events: []*history.HistoryEvent{
+				events["started"],
+				events["child workflow initiated"],
+				events["child workflow started"],
+				events["child workflow completed"],
+			},
+			expectedChilds: []ExecutionState{
+				&WorkflowExecutionState{
+					Type:   &common.WorkflowType{Name: "baz"},
+					Status: enums.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+					Execution: &common.WorkflowExecution{
+						WorkflowId: "childWfId", RunId: "childRunId",
+					},
+				},
+			},
+		},
+		"child workflow failed": {
+			events: []*history.HistoryEvent{
+				events["started"],
+				events["child workflow initiated"],
+				events["child workflow started"],
+				events["child workflow failed"],
+			},
+			expectedChilds: []ExecutionState{
+				&WorkflowExecutionState{
+					Type:   &common.WorkflowType{Name: "baz"},
+					Status: enums.WORKFLOW_EXECUTION_STATUS_FAILED,
+					Execution: &common.WorkflowExecution{
+						WorkflowId: "childWfId", RunId: "childRunId",
+					},
+					Failure: &failure.Failure{
+						Message: "This child failed us",
+					},
+					RetryState: enums.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
+				},
+			},
+		},
+		"child workflow canceled": {
+			events: []*history.HistoryEvent{
+				events["started"],
+				events["child workflow initiated"],
+				events["child workflow started"],
+				events["child workflow canceled"],
+			},
+			expectedChilds: []ExecutionState{
+				&WorkflowExecutionState{
+					Type:   &common.WorkflowType{Name: "baz"},
+					Status: enums.WORKFLOW_EXECUTION_STATUS_CANCELED,
+					Execution: &common.WorkflowExecution{
+						WorkflowId: "childWfId", RunId: "childRunId",
+					},
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			state := NewWorkflowExecutionState("foo", "")
+			for _, event := range tt.events {
+				state.Update(event)
+			}
+			assert.Equal(t, tt.expectedChilds, state.ChildStates)
+		})
+	}
+}
+
+func TestExecutionState_UpdateTimers(t *testing.T) {
+	tests := map[string]struct {
+		events         []*history.HistoryEvent
+		expectedChilds []ExecutionState
+	}{
+		"timer started": {
+			events: []*history.HistoryEvent{events["started"], events["timer started"]},
+			expectedChilds: []ExecutionState{
+				&TimerExecutionState{
+					TimerId:            "20",
+					StartToFireTimeout: NewDuration(time.Hour),
+					Status:             TIMER_STATUS_WAITING,
+				},
+			},
+		},
+		"timer fired": {
+			events: []*history.HistoryEvent{events["started"], events["timer started"], events["timer fired"]},
+			expectedChilds: []ExecutionState{
+				&TimerExecutionState{
+					TimerId:            "20",
+					StartToFireTimeout: NewDuration(time.Hour),
+					Status:             TIMER_STATUS_FIRED,
+				},
+			},
+		},
+		"timer canceled": {
+			events: []*history.HistoryEvent{events["started"], events["timer started"], events["timer canceled"]},
+			expectedChilds: []ExecutionState{
+				&TimerExecutionState{
+					TimerId:            "20",
+					StartToFireTimeout: NewDuration(time.Hour),
+					Status:             TIMER_STATUS_CANCELED,
+				},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			state := NewWorkflowExecutionState("foo", "")
+			for _, event := range tt.events {
+				state.Update(event)
+			}
+			assert.Equal(t, tt.expectedChilds, state.ChildStates)
+		})
+	}
+}
+
+func TestExecutionState_TimerExecutionStateImplementation(t *testing.T) {
+	type expectations struct {
+		Name       string
+		Attempt    int32
+		Failure    *failure.Failure
+		RetryState enums.RetryState
+		Duration   *time.Duration
+		StartTime  *time.Time
+	}
+	tests := map[string]struct {
+		State    *TimerExecutionState
+		Expected expectations
+	}{
+		"waiting timer": {
+			State: &TimerExecutionState{
+				TimerId:            "12",
+				StartToFireTimeout: NewDuration(time.Hour),
+				Status:             TIMER_STATUS_WAITING,
+				StartTime:          NewTime(0),
+			},
+			Expected: expectations{
+				Name:       "Timer (1h0m0s)",
+				Attempt:    1,
+				Failure:    nil,
+				RetryState: 0,
+				Duration:   nil,
+				StartTime:  NewTime(0),
+			},
+		},
+		"fired timer": {
+			State: &TimerExecutionState{
+				TimerId:            "12",
+				StartToFireTimeout: NewDuration(time.Hour),
+				Status:             TIMER_STATUS_FIRED,
+				StartTime:          NewTime(0),
+				CloseTime:          NewTime(time.Hour),
+			},
+			Expected: expectations{
+				Name:       "Timer (1h0m0s)",
+				Attempt:    1,
+				Failure:    nil,
+				RetryState: 0,
+				Duration:   NewDuration(time.Hour),
+				StartTime:  NewTime(0),
+			},
+		},
+		"canceled timer ": {
+			State: &TimerExecutionState{
+				TimerId:            "12",
+				StartToFireTimeout: NewDuration(time.Hour),
+				Status:             TIMER_STATUS_CANCELED,
+				StartTime:          NewTime(0),
+				CloseTime:          NewTime(30 * time.Minute),
+			},
+			Expected: expectations{
+				Name:       "Timer (1h0m0s)",
+				Attempt:    1,
+				Failure:    nil,
+				RetryState: 0,
+				Duration:   NewDuration(30 * time.Minute),
+				StartTime:  NewTime(0),
+			},
+		},
+		"named timer": {
+			State: &TimerExecutionState{
+				TimerId:            "12",
+				Name:               "TestTimer",
+				StartToFireTimeout: NewDuration(time.Hour),
+				Status:             TIMER_STATUS_WAITING,
+				StartTime:          NewTime(0),
+			},
+			Expected: expectations{
+				Name:       "TestTimer timer (1h0m0s)",
+				Attempt:    1,
+				Failure:    nil,
+				RetryState: 0,
+				Duration:   nil,
+				StartTime:  NewTime(0),
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.Expected.Name, tt.State.GetName(), "GetName")
+			assert.Equal(t, tt.Expected.Attempt, tt.State.GetAttempt(), "GetAttempt")
+			assert.Equal(t, tt.Expected.Failure, tt.State.GetFailure(), "GetFailure")
+			assert.Equal(t, tt.Expected.RetryState, tt.State.GetRetryState(), "GetRetryState")
+			assert.Equal(t, tt.Expected.Duration, tt.State.GetDuration(), fmt.Sprintf("GetDuration missmatch (expected %s, got %s)", tt.Expected.Duration, tt.State.GetDuration()))
+			assert.Equal(t, tt.Expected.StartTime, tt.State.GetStartTime(), "GetStartTime")
+		})
+	}
+}


### PR DESCRIPTION
## What was changed
This PR adds the `ExecutionState` interface which is necessary to implement the trace. The ExecutionState provides a common interface to any execution (Workflows, Activities and Timers in this case) updated through HistoryEvents. We will use this to keep updated information about workflow executions and their childs so we can represent it in the terminal.

Due to this more extended concept of executions (maybe we should use another name for this?) not being in the Temporal SDK, we have implemented Status for both Activities and Timers so we can know the state of those.

Child Workflows can be updated through the parent (using `EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_*` events) or by updating the workflow itself. This will be implemented in another PR where the `GetHistoryEvents` and the `ExecutionState` are tied together.

## Why?
Rather than making a PR with the whole updating mechanism I thought it would be worthwhile to start with the structs that will be the backbone. I feel like these structs could eventually become part of the SDK if you find them useful, so I'd rather discuss them before proceeding.

If you prefer me to provide more information (or include the actual updating mechanism) I'll be happy to do so.

## Checklist
<!--- add/delete as needed --->

1. Closes ∅

2. How was this tested:
`execution_state_test.go` provides tests for the ExecutionState updates and some implementation details

3. Any docs updates needed?
None yet.
