### PR TITLE
Move namespace flag from global to every command

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -65,13 +65,6 @@ func NewCliApp() *cli.App {
 			Usage:   "Authorization header to set for gRPC requests",
 			EnvVars: []string{"TEMPORAL_CLI_AUTH"},
 		},
-		&cli.StringFlag{
-			Name:    FlagNamespace,
-			Aliases: FlagNamespaceAlias,
-			Value:   "default",
-			Usage:   "Temporal workflow namespace",
-			EnvVars: []string{"TEMPORAL_CLI_NAMESPACE"},
-		},
 		&cli.IntFlag{
 			Name:    FlagContextTimeout,
 			Aliases: FlagContextTimeoutAlias,
@@ -138,7 +131,7 @@ func NewCliApp() *cli.App {
 			Value: string(color.Auto),
 		},
 	}
-	app.Commands = tctlCommands
+	app.Commands = withFlags(tctlCommands, sharedFlags)
 	app.Before = configureSDK
 	app.After = stopPlugins
 	app.ExitErrHandler = handleError

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -128,25 +128,25 @@ func (s *cliAppSuite) TestAppCommands() {
 
 func (s *cliAppSuite) TestNamespaceRegister_LocalNamespace() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "false"})
+	err := s.app.Run([]string{"", "namespace", "register", "--namespace", cliTestNamespace, "--global-namespace", "false"})
 	s.NoError(err)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_GlobalNamespace() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "true"})
+	err := s.app.Run([]string{"", "namespace", "register", "--namespace", cliTestNamespace, "--global-namespace", "true"})
 	s.NoError(err)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_NamespaceExist() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceAlreadyExists(""))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "true"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "register", "--namespace", cliTestNamespace, "--global-namespace", "true"})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_Failed() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "true"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "register", "--namespace", cliTestNamespace, "--global-namespace", "true"})
 	s.Equal(1, errorCode)
 }
 
@@ -176,9 +176,9 @@ func (s *cliAppSuite) TestNamespaceUpdate() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, nil).Times(2)
 	s.frontendClient.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "update"})
+	err := s.app.Run([]string{"", "namespace", "update", "--namespace", cliTestNamespace})
 	s.Nil(err)
-	err = s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "update", "--description", "another desc", "--owner-email", "another@uber.com", "--retention", "1"})
+	err = s.app.Run([]string{"", "namespace", "update", "--namespace", cliTestNamespace, "--description", "another desc", "--owner-email", "another@uber.com", "--retention", "1"})
 	s.Nil(err)
 }
 
@@ -186,13 +186,13 @@ func (s *cliAppSuite) TestNamespaceUpdate_NamespaceNotExist() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, nil)
 	s.frontendClient.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "update"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "update", "--namespace", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceUpdate_ActiveClusterFlagNotSet_NamespaceNotExist() {
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "update"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "update", "--namespace", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
@@ -200,14 +200,14 @@ func (s *cliAppSuite) TestNamespaceUpdate_Failed() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, nil)
 	s.frontendClient.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "update"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "update", "--namespace", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceDescribe() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), &workflowservice.DescribeNamespaceRequest{Namespace: cliTestNamespace, Id: ""}).Return(resp, nil)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "describe"})
+	err := s.app.Run([]string{"", "namespace", "describe", "--namespace", cliTestNamespace})
 	s.Nil(err)
 }
 
@@ -221,14 +221,14 @@ func (s *cliAppSuite) TestNamespaceDescribe_ById() {
 func (s *cliAppSuite) TestNamespaceDescribe_NamespaceNotExist() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, serviceerror.NewNamespaceNotFound("missing-namespace"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "describe"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "describe", "--namespace", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceDescribe_Failed() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "describe"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "describe", "--namespace", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
@@ -238,19 +238,19 @@ var (
 
 func (s *cliAppSuite) TestShowHistory() {
 	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", "", mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "show", "--workflow-id", "wid"})
+	err := s.app.Run([]string{"", "workflow", "show", "--namespace", cliTestNamespace, "--workflow-id", "wid"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestShowHistoryWithFollow() {
 	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", "", mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "show", "--workflow-id", "wid", "--follow"})
+	err := s.app.Run([]string{"", "workflow", "show", "--namespace", cliTestNamespace, "--workflow-id", "wid", "--follow"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 
 	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", "", mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
-	err = s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "show", "--workflow-id", "wid", "--fields", "long", "--follow"})
+	err = s.app.Run([]string{"", "workflow", "show", "--namespace", cliTestNamespace, "--workflow-id", "wid", "--fields", "long", "--follow"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
@@ -259,7 +259,7 @@ func (s *cliAppSuite) TestStartWorkflow() {
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 
 	// start with wid
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "start", "--task-queue", "testTaskQueue", "--type", "testWorkflowType", "--execution-timeout", "60", "--run-timeout", "60", "--workflow-id", "wid", "--workflow-id-reuse-policy", "Unspecified"})
+	err := s.app.Run([]string{"", "workflow", "start", "--namespace", cliTestNamespace, "--task-queue", "testTaskQueue", "--type", "testWorkflowType", "--execution-timeout", "60", "--run-timeout", "60", "--workflow-id", "wid", "--workflow-id-reuse-policy", "Unspecified"})
 	s.Nil(err)
 	s.sdkClient.AssertNotCalled(s.T(), "GetWorkflowHistory")
 	s.sdkClient.AssertExpectations(s.T())
@@ -271,7 +271,7 @@ func (s *cliAppSuite) TestStartWorkflow() {
 
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 	// start without wid
-	err = s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "start", "--task-queue", "testTaskQueue", "--type", "testWorkflowType", "--execution-timeout", "60", "--run-timeout", "60", "--workflow-id-reuse-policy", "Unspecified"})
+	err = s.app.Run([]string{"", "workflow", "start", "--namespace", cliTestNamespace, "--task-queue", "testTaskQueue", "--type", "testWorkflowType", "--execution-timeout", "60", "--run-timeout", "60", "--workflow-id-reuse-policy", "Unspecified"})
 	s.Nil(err)
 	s.sdkClient.AssertNotCalled(s.T(), "GetWorkflowHistory")
 	s.sdkClient.AssertExpectations(s.T())
@@ -281,7 +281,7 @@ func (s *cliAppSuite) TestStartWorkflow() {
 func (s *cliAppSuite) TestStartWorkflow_SearchAttributes() {
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 	// start with basic search attributes
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "start", "--task-queue", "testTaskQueue", "--type", "testWorkflowType",
+	err := s.app.Run([]string{"", "workflow", "start", "--namespace", cliTestNamespace, "--task-queue", "testTaskQueue", "--type", "testWorkflowType",
 		"--search-attribute-key", "k1", "--search-attribute-value", "\"v1\"", "--search-attribute-key", "k2", "--search-attribute-value", "\"v2\""})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
@@ -302,7 +302,7 @@ func (s *cliAppSuite) TestStartWorkflow_Failed() {
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), serviceerror.NewInvalidArgument("fake error"))
 
 	// start with wid
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "workflow", "start", "--task-queue", "testTaskQueue", "--type", "testWorkflowType", "--execution-timeout", "60", "--run-timeout", "60", "--workflow-id", "wid"})
+	errorCode := s.RunWithExitCode([]string{"", "workflow", "start", "--namespace", cliTestNamespace, "--task-queue", "testTaskQueue", "--type", "testWorkflowType", "--execution-timeout", "60", "--run-timeout", "60", "--workflow-id", "wid"})
 	s.Equal(1, errorCode)
 	s.sdkClient.AssertExpectations(s.T())
 }
@@ -311,7 +311,7 @@ func (s *cliAppSuite) TestExecuteWorkflow() {
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 	s.sdkClient.On("GetWorkflowHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
 
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "execute", "--task-queue", "testTaskQueue", "--type", "testWorkflowType"})
+	err := s.app.Run([]string{"", "workflow", "execute", "--namespace", cliTestNamespace, "--task-queue", "testTaskQueue", "--type", "testWorkflowType"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
@@ -319,41 +319,41 @@ func (s *cliAppSuite) TestExecuteWorkflow() {
 func (s *cliAppSuite) TestTerminateWorkflow() {
 	s.sdkClient.On("TerminateWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "terminate", "--workflow-id", "wid"})
+	err := s.app.Run([]string{"", "workflow", "terminate", "--namespace", cliTestNamespace, "--workflow-id", "wid"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestTerminateWorkflow_Failed() {
 	s.sdkClient.On("TerminateWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(serviceerror.NewInvalidArgument("faked error")).Once()
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "workflow", "terminate", "--workflow-id", "wid"})
+	errorCode := s.RunWithExitCode([]string{"", "workflow", "terminate", "--namespace", cliTestNamespace, "--workflow-id", "wid"})
 	s.Equal(1, errorCode)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestCancelWorkflow() {
 	s.sdkClient.On("CancelWorkflow", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "cancel", "--workflow-id", "wid"})
+	err := s.app.Run([]string{"", "workflow", "cancel", "--namespace", cliTestNamespace, "--workflow-id", "wid"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestCancelWorkflow_Failed() {
 	s.sdkClient.On("CancelWorkflow", mock.Anything, mock.Anything, mock.Anything).Return(serviceerror.NewInvalidArgument("faked error")).Once()
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "workflow", "cancel", "--workflow-id", "wid"})
+	errorCode := s.RunWithExitCode([]string{"", "workflow", "cancel", "--namespace", cliTestNamespace, "--workflow-id", "wid"})
 	s.Equal(1, errorCode)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestSignalWorkflow() {
 	s.frontendClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, nil)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "signal", "--workflow-id", "wid", "--name", "signal-name"})
+	err := s.app.Run([]string{"", "workflow", "signal", "--namespace", cliTestNamespace, "--workflow-id", "wid", "--name", "signal-name"})
 	s.Nil(err)
 }
 
 func (s *cliAppSuite) TestSignalWorkflow_Failed() {
 	s.frontendClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "workflow", "signal", "--workflow-id", "wid", "--name", "signal-name"})
+	errorCode := s.RunWithExitCode([]string{"", "workflow", "signal", "--namespace", cliTestNamespace, "--workflow-id", "wid", "--name", "signal-name"})
 	s.Equal(1, errorCode)
 }
 
@@ -362,7 +362,7 @@ func (s *cliAppSuite) TestQueryWorkflow() {
 		QueryResult: payloads.EncodeString("query-result"),
 	}
 	s.frontendClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(resp, nil)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "query", "--workflow-id", "wid", "--query-type", "query-type-test"})
+	err := s.app.Run([]string{"", "workflow", "query", "--namespace", cliTestNamespace, "--workflow-id", "wid", "--query-type", "query-type-test"})
 	s.Nil(err)
 }
 
@@ -371,7 +371,7 @@ func (s *cliAppSuite) TestQueryWorkflowUsingStackTrace() {
 		QueryResult: payloads.EncodeString("query-result"),
 	}
 	s.frontendClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(resp, nil)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "stack", "--workflow-id", "wid"})
+	err := s.app.Run([]string{"", "workflow", "stack", "--namespace", cliTestNamespace, "--workflow-id", "wid"})
 	s.Nil(err)
 }
 
@@ -380,7 +380,7 @@ func (s *cliAppSuite) TestQueryWorkflow_Failed() {
 		QueryResult: payloads.EncodeString("query-result"),
 	}
 	s.frontendClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(resp, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "workflow", "query", "--workflow-id", "wid", "--query-type", "query-type-test"})
+	errorCode := s.RunWithExitCode([]string{"", "workflow", "query", "--namespace", cliTestNamespace, "--workflow-id", "wid", "--query-type", "query-type-test"})
 	s.Equal(1, errorCode)
 }
 
@@ -418,7 +418,7 @@ var (
 
 func (s *cliAppSuite) TestListWorkflow() {
 	s.sdkClient.On("ListWorkflow", mock.Anything, mock.Anything).Return(listWorkflowExecutionsResponse, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "list"})
+	err := s.app.Run([]string{"", "workflow", "list", "--namespace", cliTestNamespace})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
@@ -426,33 +426,33 @@ func (s *cliAppSuite) TestListWorkflow() {
 func (s *cliAppSuite) TestListWorkflow_DeadlineExceeded() {
 	s.sdkClient.On("ListWorkflow", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded).Once()
 	s.sdkClient.On("ListWorkflow", mock.Anything, mock.Anything).Return(listWorkflowExecutionsResponse, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "list"})
+	err := s.app.Run([]string{"", "workflow", "list", "--namespace", cliTestNamespace})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestListWorkflow_Open_WithQuery() {
 	s.sdkClient.On("ListWorkflow", mock.Anything, mock.Anything).Return(listWorkflowExecutionsResponse, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "list", "--query", "ExecutionStatus='Running'"})
+	err := s.app.Run([]string{"", "workflow", "list", "--namespace", cliTestNamespace, "--query", "ExecutionStatus='Running'"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestListArchivedWorkflow() {
 	s.sdkClient.On("ListArchivedWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.ListArchivedWorkflowExecutionsResponse{}, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "list", "--archived", "--query", "some query string"})
+	err := s.app.Run([]string{"", "workflow", "list", "--namespace", cliTestNamespace, "--archived", "--query", "some query string"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestCountWorkflow() {
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{}, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "count"})
+	err := s.app.Run([]string{"", "workflow", "count", "--namespace", cliTestNamespace})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{}, nil).Once()
-	err = s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "count", "--query", "'CloseTime = missing'"})
+	err = s.app.Run([]string{"", "workflow", "count", "--namespace", cliTestNamespace, "--query", "'CloseTime = missing'"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
@@ -460,7 +460,7 @@ func (s *cliAppSuite) TestCountWorkflow() {
 func (s *cliAppSuite) TestCountWorkflowDeadlineExceeded() {
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded).Once()
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{}, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "count", "--query", "'CloseTime = missing'"})
+	err := s.app.Run([]string{"", "workflow", "count", "--namespace", cliTestNamespace, "--query", "'CloseTime = missing'"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
@@ -476,14 +476,14 @@ var describeTaskQueueResponse = &workflowservice.DescribeTaskQueueResponse{
 
 func (s *cliAppSuite) TestDescribeTaskQueue() {
 	s.sdkClient.On("DescribeTaskQueue", mock.Anything, mock.Anything, mock.Anything).Return(describeTaskQueueResponse, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "task-queue", "describe", "--task-queue", "test-taskQueue"})
+	err := s.app.Run([]string{"", "task-queue", "describe", "--namespace", cliTestNamespace, "--task-queue", "test-taskQueue"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestDescribeTaskQueue_Activity() {
 	s.sdkClient.On("DescribeTaskQueue", mock.Anything, mock.Anything, mock.Anything).Return(describeTaskQueueResponse, nil).Once()
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "task-queue", "describe", "--task-queue", "test-taskQueue", "--task-queue-type", "activity"})
+	err := s.app.Run([]string{"", "task-queue", "describe", "--namespace", cliTestNamespace, "--task-queue", "test-taskQueue", "--task-queue-type", "activity"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
@@ -608,7 +608,7 @@ func (s *cliAppSuite) TestGetSearchAttributes() {
 	s.sdkClient.AssertExpectations(s.T())
 
 	s.sdkClient.On("GetSearchAttributes", mock.Anything).Return(&workflowservice.GetSearchAttributesResponse{}, nil).Once()
-	err = s.app.Run([]string{"", "--namespace", cliTestNamespace, "cluster", "list-search-attributes"})
+	err = s.app.Run([]string{"", "cluster", "list-search-attributes", "--namespace", cliTestNamespace})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -59,3 +59,13 @@ var tctlCommands = []*cli.Command{
 	},
 	newAliasCommand(),
 }
+
+var sharedFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    FlagNamespace,
+		Aliases: FlagNamespaceAlias,
+		Value:   "default",
+		Usage:   "Namespace to operate on",
+		EnvVars: []string{"TEMPORAL_CLI_NAMESPACE"},
+	},
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -118,10 +118,6 @@ func newConfigCommands() []*cli.Command {
 					Usage: "Opt-in to a new TCTL UX, values: (current, next)",
 				},
 				&cli.StringFlag{
-					Name:  FlagNamespace,
-					Usage: "Default namespace",
-				},
-				&cli.StringFlag{
 					Name:  FlagAddress,
 					Usage: "host:port for Temporal frontend service",
 					Value: localHostPort,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -26,6 +26,7 @@ package cli
 
 import (
 	"fmt"
+
 	"github.com/temporalio/tctl-kit/pkg/output"
 	"github.com/urfave/cli/v2"
 )
@@ -130,7 +131,6 @@ var (
 	FlagVisibilityArchivalURI         = "visibility-uri"
 	FlagVisibilityArchivalURIAlias    = []string{"vuri"}
 	FlagName                          = "name"
-	FlagNameAlias                     = []string{"n"}
 	FlagOutputFilename                = "output-filename"
 	FlagOutputFilenameAlias           = []string{"of"}
 	FlagOutputFormat                  = "output"

--- a/cli/namespace.go
+++ b/cli/namespace.go
@@ -71,7 +71,7 @@ func newNamespaceCommands() []*cli.Command {
 		{
 			Name:    "describe",
 			Aliases: []string{"d"},
-			Usage:   "Describe a Namespace by name or ID",
+			Usage:   "Describe a Namespace by name or Id",
 			Flags:   describeNamespaceFlags,
 			Action: func(c *cli.Context) error {
 				return DescribeNamespace(c)

--- a/cli/namespace.go
+++ b/cli/namespace.go
@@ -71,7 +71,7 @@ func newNamespaceCommands() []*cli.Command {
 		{
 			Name:    "describe",
 			Aliases: []string{"d"},
-			Usage:   "Describe a Namespace",
+			Usage:   "Describe a Namespace by name or ID",
 			Flags:   describeNamespaceFlags,
 			Action: func(c *cli.Context) error {
 				return DescribeNamespace(c)

--- a/cli/namespace_commands.go
+++ b/cli/namespace_commands.go
@@ -348,10 +348,10 @@ func ListNamespaces(c *cli.Context) error {
 
 // DeleteNamespace deletes namespace.
 func DeleteNamespace(c *cli.Context) error {
-	nsName := c.String(FlagName)
+	nsName := c.String(FlagNamespace)
 
 	if nsName == "" {
-		return fmt.Errorf("provide %s flag", FlagName)
+		return fmt.Errorf("provide %s flag", FlagNamespace)
 	}
 
 	promptMsg := color.Red(c, "Are you sure you want to delete namespace %s? Type namespace name to confirm:", nsName)

--- a/cli/namespace_utils.go
+++ b/cli/namespace_utils.go
@@ -165,18 +165,13 @@ var (
 	describeNamespaceFlags = []cli.Flag{
 		&cli.StringFlag{
 			Name:  FlagNamespaceID,
-			Usage: "Namespace Id (required if not specify namespace)",
+			Usage: "Namespace Id",
 		},
 	}
 
 	listNamespacesFlags []cli.Flag
 
 	deleteNamespacesFlags = []cli.Flag{
-		&cli.StringFlag{
-			Name:    FlagName,
-			Aliases: FlagNameAlias,
-			Usage:   "Namespace name to delete",
-		},
 		&cli.BoolFlag{
 			Name:    FlagYes,
 			Aliases: FlagYesAlias,

--- a/cli/util.go
+++ b/cli/util.go
@@ -368,7 +368,7 @@ func getSDKClient(c *cli.Context) (sdkclient.Client, error) {
 func getRequiredGlobalOption(c *cli.Context, optionName string) (string, error) {
 	value := readFlagOrConfig(c, optionName)
 	if len(value) == 0 {
-		return "", fmt.Errorf("global option is required: %s", optionName)
+		return "", fmt.Errorf("option is required: %s", optionName)
 	}
 	return value, nil
 }
@@ -793,4 +793,39 @@ func parseFoldStatusList(flagValue string) ([]enumspb.WorkflowExecutionStatus, e
 		}
 	}
 	return statusList, nil
+}
+
+func withFlags(commands []*cli.Command, newFlags []cli.Flag) []*cli.Command {
+	for _, c := range tctlCommands {
+		for _, subc := range c.Subcommands {
+			for _, newF := range newFlags {
+				flagExists := false
+				for _, subf := range subc.Flags {
+					if intersects(subf.Names(), newF.Names()) {
+						flagExists = true
+						continue
+					}
+				}
+
+				if !flagExists {
+					subc.Flags = append([]cli.Flag{newF}, subc.Flags...)
+				} else {
+					// fmt.Printf("WARNING: flag %s already exists in command %s %s\n", newF.Names(), c.Name, subc.Name)
+				}
+			}
+		}
+	}
+
+	return commands
+}
+
+func intersects(slice1 []string, slice2 []string) bool {
+	for _, s1 := range slice1 {
+		for _, s2 := range slice2 {
+			if s1 == s2 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -114,7 +114,6 @@ func newWorkflowCommands() []*cli.Command {
 			Flags: append(flagsForExecution, []cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagName,
-					Aliases:  FlagNameAlias,
 					Usage:    "Signal Name",
 					Required: true,
 				},


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

--namespace flag now lives under each subcommand instead of as a global flag

## Why?
<!-- Tell your future self why have you made these changes -->

- Namaspace relates to specific Temporal actions rather than global property (TLS, auth) 
- changes the syntax from `tctl  --namespace canary namespace register` to `tctl namespace register --namespace canary`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- unit tests
- registered and deleted namespace

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
