### PR TITLE
Change config semantics to args and full key path

### DIFF
--- a/cli/schedule_commands.go
+++ b/cli/schedule_commands.go
@@ -398,7 +398,7 @@ func BackfillSchedule(c *cli.Context) error {
 		ScheduleId: scheduleID,
 		Patch: &schedpb.SchedulePatch{
 			BackfillRequest: []*schedpb.BackfillRequest{
-				&schedpb.BackfillRequest{
+				{
 					StartTime:     timestamp.TimePtr(startTime),
 					EndTime:       timestamp.TimePtr(endTime),
 					OverlapPolicy: overlap,

--- a/cli/util.go
+++ b/cli/util.go
@@ -328,7 +328,7 @@ func getCurrentUserFromEnv() string {
 			return os.Getenv(n)
 		}
 	}
-	return "unkown"
+	return "unknown"
 }
 
 func prettyPrintJSONObject(o interface{}) {
@@ -378,12 +378,7 @@ func readFlagOrConfig(c *cli.Context, key string) string {
 		return c.String(key)
 	}
 
-	var cVal string
-	if isRootKey(key) {
-		cVal, _ = tctlConfig.Get(c, key)
-	} else if isEnvKey(key) {
-		cVal, _ = tctlConfig.GetByEnvironment(c, key)
-	}
+	cVal, _ := tctlConfig.GetByCurrentEnvironment(key)
 
 	if cVal != "" {
 		return cVal

--- a/cli_curr/config.go
+++ b/cli_curr/config.go
@@ -70,7 +70,7 @@ func GetValue(c *cli.Context) error {
 		return fmt.Errorf("unable to get property %v. %s", key, err)
 	}
 
-	val, err := tctlConfig.Get(nil, key)
+	val, err := tctlConfig.Get(key)
 	if err != nil {
 		return fmt.Errorf("unable to get property %v. %s", key, err)
 	}
@@ -90,7 +90,7 @@ func SetValue(c *cli.Context) error {
 		return fmt.Errorf("unable to set property %v. %s", key, err)
 	}
 
-	if err := tctlConfig.Set(nil, key, val); err != nil {
+	if err := tctlConfig.Set(key, val); err != nil {
 		return fmt.Errorf("unable to set property %v. %s", key, err)
 	}
 

--- a/cmd/tctl/main.go
+++ b/cmd/tctl/main.go
@@ -35,7 +35,7 @@ import (
 // See https://docs.temporal.io/docs/system-tools/tctl/ for usage
 func main() {
 	tctlConfig, _ := config.NewTctlConfig()
-	version, _ := tctlConfig.Get(nil, "version")
+	version, _ := tctlConfig.Get("version")
 
 	if version == "next" {
 		appNext := cli.NewCliApp()

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/olivere/elastic/v7 v7.0.32
 	github.com/pborman/uuid v1.2.1
 	github.com/stretchr/testify v1.8.0
-	github.com/temporalio/tctl-kit v0.0.0-20220512165751-9c751176dd14
+	github.com/temporalio/tctl-kit v0.0.0-20220810223931-23f1dcdbad08
 	github.com/urfave/cli v1.22.9
 	github.com/urfave/cli/v2 v2.10.2
 	go.temporal.io/api v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -479,6 +479,8 @@ github.com/temporalio/ringpop-go v0.0.0-20211012191444-6f91b5915e95 h1:8G34e73qt
 github.com/temporalio/ringpop-go v0.0.0-20211012191444-6f91b5915e95/go.mod h1:Ek9J8CAfI1IwVSqHpTOgj7FjzRSJ5SM/ud52eCmkhsw=
 github.com/temporalio/tctl-kit v0.0.0-20220512165751-9c751176dd14 h1:4qVgd+wa3QAJL+CAZbxJUaOaygOeRXgQTNGJ10cUp5E=
 github.com/temporalio/tctl-kit v0.0.0-20220512165751-9c751176dd14/go.mod h1:2Ef/g3r5xjrvCe36AX4SXS0IUhD1plwwexNyVn8TB4I=
+github.com/temporalio/tctl-kit v0.0.0-20220810223931-23f1dcdbad08 h1:PMXGN2MzWUFCdaVm7K38spW7NNKRwUNyPNjb2OBlAu8=
+github.com/temporalio/tctl-kit v0.0.0-20220810223931-23f1dcdbad08/go.mod h1:2Ef/g3r5xjrvCe36AX4SXS0IUhD1plwwexNyVn8TB4I=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

changes config feature semantics from flags to args

`tctl config set --namespace accounting` 

to 

`tctl config set env.local.namespace accounting`  (or `tctl config set namespace accounting` for short in a new PR)

## Why?
<!-- Tell your future self why have you made these changes -->

- moving towards allowing to configure the default value for any flag and not just the ones whitelisted by `tctl config set` command   
- consistency with other tools such as `git` and `kubectl` 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
