### PR TITLE
Call service api for admin workflow delete command

### DIFF
--- a/cli_curr/admin.go
+++ b/cli_curr/admin.go
@@ -111,8 +111,7 @@ func newAdminWorkflowCommands() []cli.Command {
 			Name:    "delete",
 			Aliases: []string{"del"},
 			Usage:   "Delete current workflow execution and the mutableState record",
-			Flags: append(
-				getDBAndESFlags(),
+			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  FlagWorkflowIDWithAlias,
 					Usage: "WorkflowId",
@@ -122,9 +121,10 @@ func newAdminWorkflowCommands() []cli.Command {
 					Usage: "RunId",
 				},
 				cli.BoolFlag{
-					Name:  FlagSkipErrorModeWithAlias,
-					Usage: "skip errors",
-				}),
+					Name:  FlagYes,
+					Usage: "Optional flag to disable confirmation prompt",
+				},
+			},
 			Action: func(c *cli.Context) {
 				AdminDeleteWorkflow(c)
 			},


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Call service api for admin workflow delete command

## Why?
<!-- Tell your future self why have you made these changes -->
- For 1.17.3 release. Server doesn't have tdbg in 1.17 release. But customer may this admin workflow to delete some corrupted workflows

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
