### PR TITLE
Add commands for worker build id based versioning

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -254,6 +254,11 @@ var (
 	FlagNoFold                        = "no-fold"
 	FlagDepth                         = "depth"
 	FlagDepthAlias                    = []string{"d"}
+	FlagWorkerBuildId                 = "build-id"
+	FlagWorkerBuildIdAlias            = []string{"bid"}
+	FlagWorkerBuildIdMakeDefault      = "set-default"
+	FlagWorkerBuildIdPreviousCompat   = "previous-compatible"
+	FlagGetBuildIDGraphMaxDepth       = "max-depth"
 
 	FlagProtoType  = "type"
 	FlagHexData    = "hex-data"

--- a/cli/task_queue.go
+++ b/cli/task_queue.go
@@ -35,7 +35,7 @@ func newTaskQueueCommands() []*cli.Command {
 		{
 			Name:    "describe",
 			Aliases: []string{"d"},
-			Usage:   "Describe pollers info of task queue",
+			Usage:   "Describe the Task Queue and its pollers",
 			Flags: append([]cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagTaskQueue,
@@ -57,7 +57,7 @@ func newTaskQueueCommands() []*cli.Command {
 		{
 			Name:    "list-partition",
 			Aliases: []string{"lp"},
-			Usage:   "List all the taskqueue partitions and the hostname for partitions",
+			Usage:   "List all the Task Queue partitions and the hostname for partitions",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagTaskQueue,
@@ -74,6 +74,59 @@ func newTaskQueueCommands() []*cli.Command {
 			},
 			Action: func(c *cli.Context) error {
 				return ListTaskQueuePartitions(c)
+			},
+		},
+		{
+			Name:    "update-versions",
+			Aliases: []string{"uv"},
+			Usage:   "Update the Task Queue's worker build id version graph",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     FlagTaskQueue,
+					Aliases:  FlagTaskQueueAlias,
+					Usage:    "Task Queue name",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:     FlagWorkerBuildId,
+					Aliases:  FlagWorkerBuildIdAlias,
+					Usage:    "Worker build id to add or modify",
+					Required: true,
+				},
+				&cli.BoolFlag{
+					Name:  FlagWorkerBuildIdMakeDefault,
+					Usage: "If set, make this build id the default version for new workflows started on the task queue",
+				},
+				&cli.StringFlag{
+					Name: FlagWorkerBuildIdPreviousCompat,
+					Usage: "If set, indicates that this version should be considered compatible with the version" +
+						" provided by this flag.",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				return UpdateWorkerBuildIDVersionGraph(c)
+			},
+		},
+		{
+			Name:    "get-versions",
+			Aliases: []string{"gv"},
+			Usage:   "Fetches the Task Queue's worker build id version graph",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     FlagTaskQueue,
+					Aliases:  FlagTaskQueueAlias,
+					Usage:    "Task Queue name",
+					Required: true,
+				},
+				&cli.UintFlag{
+					Name: FlagGetBuildIDGraphMaxDepth,
+					Usage: "If set nonzero, limit the depth of the fetched graph. The limit applies to each branch in " +
+						"the DAG, so a value of 1 will return the current default, and one node of each compatible " +
+						"branch, if any.",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				return GetWorkerBuildIDVersionGraph(c)
 			},
 		},
 	}

--- a/cli/task_queue.go
+++ b/cli/task_queue.go
@@ -110,7 +110,7 @@ func newTaskQueueCommands() []*cli.Command {
 		{
 			Name:    "get-versions",
 			Aliases: []string{"gv"},
-			Usage:   "Fetches the Task Queue's worker build id version graph",
+			Usage:   "Fetches the Task Queue's worker build id version graph as JSON",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagTaskQueue,

--- a/cli/task_queue_commands.go
+++ b/cli/task_queue_commands.go
@@ -110,3 +110,11 @@ func ListTaskQueuePartitions(c *cli.Context) error {
 	output.PrintItems(c, items, optsA)
 	return nil
 }
+
+func UpdateWorkerBuildIDVersionGraph(c *cli.Context) error {
+	panic("not implemented")
+}
+
+func GetWorkerBuildIDVersionGraph(c *cli.Context) error {
+	panic("not implemented")
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/temporalio/tctl/v2
 
 go 1.18
 
+replace go.temporal.io/sdk => ../sdk-go
+
 require (
 	github.com/fatih/color v1.13.0
 	github.com/gogo/protobuf v1.3.2
@@ -17,7 +19,7 @@ require (
 	github.com/temporalio/tctl-kit v0.0.0-20220820043607-ce6822af0b23
 	github.com/urfave/cli v1.22.9
 	github.com/urfave/cli/v2 v2.10.2
-	go.temporal.io/api v1.10.0
+	go.temporal.io/api v1.11.0
 	go.temporal.io/sdk v1.15.1-0.20220713210017-de63fea375d5
 	go.temporal.io/server v1.16.1-0.20220803191852-3ab0bae5cd53
 	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
@@ -126,16 +128,16 @@ require (
 	go.uber.org/fx v1.17.1 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
-	golang.org/x/net v0.0.0-20220708220712-1185a9018129 // indirect
+	golang.org/x/net v0.0.0-20220728181054-f92ba40d432d // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect
-	golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e // indirect
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	google.golang.org/api v0.85.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220712132514-bdd2acd4974d // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
+	google.golang.org/genproto v0.0.0-20220725144611-272f38e5d71b // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/validator.v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -545,10 +545,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.opentelemetry.io/proto/otlp v0.16.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.18.0 h1:W5hyXNComRa23tGpKwG+FRAc4rfF6ZUg1JReK+QHS80=
 go.opentelemetry.io/proto/otlp v0.18.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
-go.temporal.io/api v1.10.0 h1:g3Q9FCzRWhgqazog1/v+ed1Yz28JDWLnlJ/epJtHAWk=
-go.temporal.io/api v1.10.0/go.mod h1:eEE/bU6fgAnzgW7Q3NNoCwmCJiivuzOBfqHYYBDDCq0=
-go.temporal.io/sdk v1.15.1-0.20220713210017-de63fea375d5 h1:A2WpNqBQ4V58Q0rkYHXydR2OPxl9InD793l2QmGrocg=
-go.temporal.io/sdk v1.15.1-0.20220713210017-de63fea375d5/go.mod h1:8c+n/kiZxLiahtHY96sHdTUbMOmdUmr4jsQfCLbzk+o=
+go.temporal.io/api v1.11.0 h1:RepwYaOZcEII7oKPC0QAUJHiep04NbwGRwMZ6Ofg0es=
+go.temporal.io/api v1.11.0/go.mod h1:Z1uAa6iqyq/lu0+41qOG+BNO2JsxXxrgUe8UJv2iNZI=
 go.temporal.io/server v1.16.1-0.20220803191852-3ab0bae5cd53 h1:vly9boOnav10c+nOEBT9bzhd1ZTyH1/keeteuhnRGYI=
 go.temporal.io/server v1.16.1-0.20220803191852-3ab0bae5cd53/go.mod h1:Rv8j0xxxsaB5txxl4sPp9laTbpnzZESgb3bkOdvWKxI=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -671,8 +669,8 @@ golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220617184016-355a448f1bc9/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20220708220712-1185a9018129 h1:vucSRfWwTsoXro7P+3Cjlr6flUMtzCwzlvkxEQtHHB0=
-golang.org/x/net v0.0.0-20220708220712-1185a9018129/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220728181054-f92ba40d432d h1:3iMzhioG3w6/URLOo7X7eZRkWoLdz9iWE/UsnXHNTfY=
+golang.org/x/net v0.0.0-20220728181054-f92ba40d432d/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -783,8 +781,8 @@ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e h1:NHvCuwuS43lGnYhten69ZWqi2QOj/CiDNcKbVqwVoew=
-golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1004,8 +1002,8 @@ google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP
 google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
-google.golang.org/genproto v0.0.0-20220712132514-bdd2acd4974d h1:YbuF5+kdiC516xIP60RvlHeFbY9sRDR73QsAGHpkeVw=
-google.golang.org/genproto v0.0.0-20220712132514-bdd2acd4974d/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20220725144611-272f38e5d71b h1:SfSkJugek6xm7lWywqth4r2iTrYLpD8lOj1nMIIhMNM=
+google.golang.org/genproto v0.0.0-20220725144611-272f38e5d71b/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -1056,8 +1054,9 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
DRAFT until SDK portion is merged


## What was changed
Add commands to interact with the new versioning feature: https://github.com/Sushisource/proposals/blob/83dce63ad681d8dccc9fb2f6996304942a7ca04e/versioning/worker-versions.md

## Why?
This is likely the most common way users will interact with the version graphs

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/cli/issues/165

2. How was this tested:
Manually verified

3. Any docs updates needed?
Will need corresponding docs changes
