### PR TITLE
Remove aliases for commands

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -86,9 +86,9 @@ func (m *clientFactoryMock) HealthClient(_ *cli.Context) healthpb.HealthClient {
 }
 
 var commands = []string{
-	"namespace", "n",
-	"workflow", "w",
-	"task-queue", "tq",
+	"namespace",
+	"workflow",
+	"task-queue",
 }
 
 var cliTestNamespace = "cli-test-namespace"

--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -35,9 +35,8 @@ import (
 func newClusterCommands() []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:    "health",
-			Aliases: []string{"h"},
-			Usage:   "Check health of frontend service",
+			Name:  "health",
+			Usage: "Check health of frontend service",
 			Action: func(c *cli.Context) error {
 				return HealthCheck(c)
 			},

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -31,31 +31,26 @@ import (
 var tctlCommands = []*cli.Command{
 	{
 		Name:        "namespace",
-		Aliases:     []string{"n"},
 		Usage:       "Operations on namespaces",
 		Subcommands: newNamespaceCommands(),
 	},
 	{
 		Name:        "workflow",
-		Aliases:     []string{"w"},
 		Usage:       "Operations on workflows",
 		Subcommands: newWorkflowCommands(),
 	},
 	{
 		Name:        "activity",
-		Aliases:     []string{"a"},
 		Usage:       "Operations on activities of workflows",
 		Subcommands: newActivityCommands(),
 	},
 	{
 		Name:        "task-queue",
-		Aliases:     []string{"tq"},
 		Usage:       "Operations on task queues",
 		Subcommands: newTaskQueueCommands(),
 	},
 	{
 		Name:        "schedule",
-		Aliases:     []string{"s"},
 		Usage:       "Operations on schedules",
 		Subcommands: newScheduleCommands(),
 	},
@@ -71,13 +66,11 @@ var tctlCommands = []*cli.Command{
 	},
 	{
 		Name:        "data-converter",
-		Aliases:     []string{"dc"},
 		Usage:       "Operations using a custom data converter",
 		Subcommands: newDataConverterCommands(),
 	},
 	{
 		Name:        "config",
-		Aliases:     []string{"c"},
 		Usage:       "Configure tctl",
 		Subcommands: newConfigCommands(),
 	},

--- a/cli/namespace.go
+++ b/cli/namespace.go
@@ -69,19 +69,17 @@ func parseNamespaceDataKVs(namespaceDataStr string) (map[string]string, error) {
 func newNamespaceCommands() []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:    "describe",
-			Aliases: []string{"d"},
-			Usage:   "Describe a Namespace by name or Id",
-			Flags:   describeNamespaceFlags,
+			Name:  "describe",
+			Usage: "Describe a Namespace by name or Id",
+			Flags: describeNamespaceFlags,
 			Action: func(c *cli.Context) error {
 				return DescribeNamespace(c)
 			},
 		},
 		{
-			Name:    "list",
-			Aliases: []string{"l"},
-			Usage:   "List all Namespaces",
-			Flags:   listNamespacesFlags,
+			Name:  "list",
+			Usage: "List all Namespaces",
+			Flags: listNamespacesFlags,
 			Action: func(c *cli.Context) error {
 				return ListNamespaces(c)
 			},

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -137,7 +137,6 @@ func newScheduleCommands() []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:        "create",
-			Aliases:     []string{"c"},
 			Usage:       "Create a new schedule",
 			Description: "Takes a schedule specification plus all the same args as starting a workflow",
 			Flags:       createFlags,
@@ -201,9 +200,8 @@ func newScheduleCommands() []*cli.Command {
 			Action: BackfillSchedule,
 		},
 		{
-			Name:    "describe",
-			Aliases: []string{"d"},
-			Usage:   "Get schedule configuration and current state",
+			Name:  "describe",
+			Usage: "Get schedule configuration and current state",
 			Flags: append([]cli.Flag{
 				sid,
 				&cli.BoolFlag{
@@ -222,11 +220,10 @@ func newScheduleCommands() []*cli.Command {
 			Action: DeleteSchedule,
 		},
 		{
-			Name:    "list",
-			Aliases: []string{"l"},
-			Usage:   "Lists schedules",
-			Flags:   append([]cli.Flag{}, flags.FlagsForPaginationAndRendering...),
-			Action:  ListSchedules,
+			Name:   "list",
+			Usage:  "Lists schedules",
+			Flags:  append([]cli.Flag{}, flags.FlagsForPaginationAndRendering...),
+			Action: ListSchedules,
 		},
 	}
 }

--- a/cli/task_queue.go
+++ b/cli/task_queue.go
@@ -33,9 +33,8 @@ import (
 func newTaskQueueCommands() []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:    "describe",
-			Aliases: []string{"d"},
-			Usage:   "Describe pollers info of task queue",
+			Name:  "describe",
+			Usage: "Describe pollers info of task queue",
 			Flags: append([]cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagTaskQueue,
@@ -55,9 +54,8 @@ func newTaskQueueCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:    "list-partition",
-			Aliases: []string{"lp"},
-			Usage:   "List all the taskqueue partitions and the hostname for partitions",
+			Name:  "list-partition",
+			Usage: "List all the taskqueue partitions and the hostname for partitions",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagTaskQueue,

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -50,9 +50,8 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:    "describe",
-			Aliases: []string{"d"},
-			Usage:   "Show information about a Workflow Execution",
+			Name:  "describe",
+			Usage: "Show information about a Workflow Execution",
 			Flags: append(flagsForExecution, []cli.Flag{
 				&cli.BoolFlag{
 					Name:  FlagResetPointsOnly,
@@ -68,10 +67,9 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:    "list",
-			Aliases: []string{"l"},
-			Usage:   "List Workflow Executions based on a Query",
-			Flags:   append(flagsForWorkflowFiltering, flags.FlagsForPaginationAndRendering...),
+			Name:  "list",
+			Usage: "List Workflow Executions based on a Query",
+			Flags: append(flagsForWorkflowFiltering, flags.FlagsForPaginationAndRendering...),
 			Action: func(c *cli.Context) error {
 				return ListWorkflow(c)
 			},
@@ -108,9 +106,8 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:    "signal",
-			Aliases: []string{"s"},
-			Usage:   "Signal a Workflow Execution",
+			Name:  "signal",
+			Usage: "Signal a Workflow Execution",
 			Flags: append(flagsForExecution, []cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagName,
@@ -276,11 +273,10 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:    "trace",
-			Aliases: []string{"t"},
-			Usage:   "Trace progress of a Workflow Execution and its children",
-			Flags:   append(flagsForExecution, flagsForTraceWorkflow...),
-			Action:  TraceWorkflow,
+			Name:   "trace",
+			Usage:  "Trace progress of a Workflow Execution and its children",
+			Flags:  append(flagsForExecution, flagsForTraceWorkflow...),
+			Action: TraceWorkflow,
 		},
 	}
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Removed all aliases for commands such as `tctl w l` for `tctl workflow list`

## Why?
<!-- Tell your future self why have you made these changes -->

decision from an API review @bergundy @alexshtin 

users still can set their own aliases using `tctl alias`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
