### PR TITLE
Remove workflow scan command

### DIFF
--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -130,14 +130,6 @@ func newWorkflowCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:  "scan",
-			Usage: "List Workflow Executions. Faster and unsorted (requires Elasticsearch to be enabled)",
-			Flags: append(flagsForScan, flags.FlagsForPaginationAndRendering...),
-			Action: func(c *cli.Context) error {
-				return ScanAllWorkflow(c)
-			},
-		},
-		{
 			Name:  "count",
 			Usage: "Count Workflow Executions (requires ElasticSearch to be enabled)",
 			Flags: getFlagsForCount(),


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Remove `workflow scan` command.

## Why?
<!-- Tell your future self why have you made these changes -->
`ScanWorkflow` API is about to be deprecated from server and should not be exposed in new `tctl`.
