### PR TITLE
Use args for namespace name instead of global flag

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -128,25 +128,25 @@ func (s *cliAppSuite) TestAppCommands() {
 
 func (s *cliAppSuite) TestNamespaceRegister_LocalNamespace() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "false"})
+	err := s.app.Run([]string{"", "namespace", "register", "--global-namespace", "false", cliTestNamespace})
 	s.NoError(err)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_GlobalNamespace() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "true"})
+	err := s.app.Run([]string{"", "namespace", "register", "--global-namespace", "true", cliTestNamespace})
 	s.NoError(err)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_NamespaceExist() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceAlreadyExists(""))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "true"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "register", "--global-namespace", "true", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_Failed() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "register", "--global-namespace", "true"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "register", "--global-namespace", "true", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
@@ -176,9 +176,9 @@ func (s *cliAppSuite) TestNamespaceUpdate() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, nil).Times(2)
 	s.frontendClient.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "update"})
+	err := s.app.Run([]string{"", "namespace", "update", cliTestNamespace})
 	s.Nil(err)
-	err = s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "update", "--description", "another desc", "--owner-email", "another@uber.com", "--retention", "1"})
+	err = s.app.Run([]string{"", "namespace", "update", "--description", "another desc", "--owner-email", "another@uber.com", "--retention", "1", cliTestNamespace})
 	s.Nil(err)
 }
 
@@ -186,13 +186,13 @@ func (s *cliAppSuite) TestNamespaceUpdate_NamespaceNotExist() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, nil)
 	s.frontendClient.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "update"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "update", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceUpdate_ActiveClusterFlagNotSet_NamespaceNotExist() {
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "update"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "update", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
@@ -200,14 +200,14 @@ func (s *cliAppSuite) TestNamespaceUpdate_Failed() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, nil)
 	s.frontendClient.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "update"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "update", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceDescribe() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), &workflowservice.DescribeNamespaceRequest{Namespace: cliTestNamespace, Id: ""}).Return(resp, nil)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "namespace", "describe"})
+	err := s.app.Run([]string{"", "namespace", "describe", cliTestNamespace})
 	s.Nil(err)
 }
 
@@ -221,14 +221,32 @@ func (s *cliAppSuite) TestNamespaceDescribe_ById() {
 func (s *cliAppSuite) TestNamespaceDescribe_NamespaceNotExist() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, serviceerror.NewNamespaceNotFound("missing-namespace"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "describe"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "describe", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceDescribe_Failed() {
 	resp := describeNamespaceResponseServer
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "namespace", "describe"})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "describe", cliTestNamespace})
+	s.Equal(1, errorCode)
+}
+
+func (s *cliAppSuite) TestNamespaceDelete() {
+	s.operatorClient.EXPECT().DeleteNamespace(gomock.Any(), &operatorservice.DeleteNamespaceRequest{Namespace: cliTestNamespace}).Return(&operatorservice.DeleteNamespaceResponse{}, nil)
+	err := s.app.Run([]string{"", "namespace", "delete", "--yes", cliTestNamespace})
+	s.Nil(err)
+}
+
+func (s *cliAppSuite) TestNamespaceDelete_NamespaceNotExist() {
+	s.operatorClient.EXPECT().DeleteNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "delete", "--yes", cliTestNamespace})
+	s.Equal(1, errorCode)
+}
+
+func (s *cliAppSuite) TestNamespaceDelete_Failed() {
+	s.operatorClient.EXPECT().DeleteNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewInvalidArgument("faked error"))
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "delete", "--yes", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -38,7 +38,7 @@ func newConfigCommands() []*cli.Command {
 			Name:      "get",
 			Usage:     "Print the value of an env property",
 			Flags:     []cli.Flag{},
-			ArgsUsage: "env.[ENV NAME].[PROPERTY NAME] or [PROPERTY NAME] for current env",
+			ArgsUsage: "[env.env_name.]property_name",
 			Action: func(c *cli.Context) error {
 				return EnvProperty(c)
 			},
@@ -47,7 +47,7 @@ func newConfigCommands() []*cli.Command {
 			Name:      "set",
 			Usage:     "Set the value of an env property",
 			Flags:     []cli.Flag{},
-			ArgsUsage: `env.[ENV NAME].[PROPERTY NAME] [VALUE] or [PROPERTY NAME] [VALUE] for current env`,
+			ArgsUsage: "[env.env_name.]property_name value",
 			Action: func(c *cli.Context) error {
 				return SetEnvProperty(c)
 			},

--- a/cli/env.go
+++ b/cli/env.go
@@ -47,7 +47,7 @@ func newEnvCommands() []*cli.Command {
 		{
 			Name:      "show-env",
 			Usage:     "Print environment properties",
-			ArgsUsage: " [ENV NAME]",
+			ArgsUsage: "env_name",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:    output.FlagOutput,
@@ -63,7 +63,7 @@ func newEnvCommands() []*cli.Command {
 			Name:      "use-env",
 			Usage:     "Switch environment",
 			Flags:     []cli.Flag{},
-			ArgsUsage: " [ENV NAME]",
+			ArgsUsage: "env_name",
 			Action: func(c *cli.Context) error {
 				return UseEnv(c)
 			},
@@ -72,7 +72,7 @@ func newEnvCommands() []*cli.Command {
 			Name:      "remove-env",
 			Usage:     "Remove environment",
 			Flags:     []cli.Flag{},
-			ArgsUsage: " [ENV NAME]",
+			ArgsUsage: "env_name",
 			Action: func(c *cli.Context) error {
 				return RemoveEnv(c)
 			},

--- a/cli/namespace.go
+++ b/cli/namespace.go
@@ -72,7 +72,7 @@ func newNamespaceCommands() []*cli.Command {
 			Name:      "describe",
 			Usage:     "Describe a Namespace by name or Id",
 			Flags:     describeNamespaceFlags,
-			ArgsUsage: "namespace-name",
+			ArgsUsage: "[NAMESPACE NAME]",
 			Action: func(c *cli.Context) error {
 				return DescribeNamespace(c)
 			},
@@ -90,7 +90,7 @@ func newNamespaceCommands() []*cli.Command {
 			Name:      "register",
 			Usage:     "Register a new Namespace",
 			Flags:     registerNamespaceFlags,
-			ArgsUsage: "namespace-name",
+			ArgsUsage: "[NAMESPACE NAME]",
 			Action: func(c *cli.Context) error {
 				return RegisterNamespace(c)
 			},
@@ -99,7 +99,7 @@ func newNamespaceCommands() []*cli.Command {
 			Name:      "update",
 			Usage:     "Update a Namespace",
 			Flags:     updateNamespaceFlags,
-			ArgsUsage: "namespace-name",
+			ArgsUsage: "[NAMESPACE NAME]",
 			Action: func(c *cli.Context) error {
 				return UpdateNamespace(c)
 			},
@@ -108,7 +108,7 @@ func newNamespaceCommands() []*cli.Command {
 			Name:      "delete",
 			Usage:     "Delete existing Namespace",
 			Flags:     deleteNamespacesFlags,
-			ArgsUsage: "namespace-name",
+			ArgsUsage: "[NAMESPACE NAME]",
 			Action: func(c *cli.Context) error {
 				return DeleteNamespace(c)
 			},

--- a/cli/namespace.go
+++ b/cli/namespace.go
@@ -69,41 +69,46 @@ func parseNamespaceDataKVs(namespaceDataStr string) (map[string]string, error) {
 func newNamespaceCommands() []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:  "describe",
-			Usage: "Describe a Namespace by name or Id",
-			Flags: describeNamespaceFlags,
+			Name:      "describe",
+			Usage:     "Describe a Namespace by name or Id",
+			Flags:     describeNamespaceFlags,
+			ArgsUsage: "namespace-name",
 			Action: func(c *cli.Context) error {
 				return DescribeNamespace(c)
 			},
 		},
 		{
-			Name:  "list",
-			Usage: "List all Namespaces",
-			Flags: listNamespacesFlags,
+			Name:      "list",
+			Usage:     "List all Namespaces",
+			Flags:     listNamespacesFlags,
+			ArgsUsage: " ",
 			Action: func(c *cli.Context) error {
 				return ListNamespaces(c)
 			},
 		},
 		{
-			Name:  "register",
-			Usage: "Register a new Namespace",
-			Flags: registerNamespaceFlags,
+			Name:      "register",
+			Usage:     "Register a new Namespace",
+			Flags:     registerNamespaceFlags,
+			ArgsUsage: "namespace-name",
 			Action: func(c *cli.Context) error {
 				return RegisterNamespace(c)
 			},
 		},
 		{
-			Name:  "update",
-			Usage: "Update a Namespace",
-			Flags: updateNamespaceFlags,
+			Name:      "update",
+			Usage:     "Update a Namespace",
+			Flags:     updateNamespaceFlags,
+			ArgsUsage: "namespace-name",
 			Action: func(c *cli.Context) error {
 				return UpdateNamespace(c)
 			},
 		},
 		{
-			Name:  "delete",
-			Usage: "Delete existing Namespace",
-			Flags: deleteNamespacesFlags,
+			Name:      "delete",
+			Usage:     "Delete existing Namespace",
+			Flags:     deleteNamespacesFlags,
+			ArgsUsage: "namespace-name",
 			Action: func(c *cli.Context) error {
 				return DeleteNamespace(c)
 			},

--- a/cli/namespace.go
+++ b/cli/namespace.go
@@ -32,7 +32,7 @@ import (
 )
 
 // by default we don't require any namespace data. But this can be overridden by calling SetRequiredNamespaceDataKeys()
-var requiredNamespaceDataKeys = []string{}
+var requiredNamespaceDataKeys []string
 
 // SetRequiredNamespaceDataKeys will set requiredNamespaceDataKeys
 func SetRequiredNamespaceDataKeys(keys []string) {
@@ -72,7 +72,7 @@ func newNamespaceCommands() []*cli.Command {
 			Name:      "describe",
 			Usage:     "Describe a Namespace by name or Id",
 			Flags:     describeNamespaceFlags,
-			ArgsUsage: "[NAMESPACE NAME]",
+			ArgsUsage: "namespace_name",
 			Action: func(c *cli.Context) error {
 				return DescribeNamespace(c)
 			},
@@ -90,7 +90,7 @@ func newNamespaceCommands() []*cli.Command {
 			Name:      "register",
 			Usage:     "Register a new Namespace",
 			Flags:     registerNamespaceFlags,
-			ArgsUsage: "[NAMESPACE NAME]",
+			ArgsUsage: "namespace_name [cluster_name...]",
 			Action: func(c *cli.Context) error {
 				return RegisterNamespace(c)
 			},
@@ -99,7 +99,7 @@ func newNamespaceCommands() []*cli.Command {
 			Name:      "update",
 			Usage:     "Update a Namespace",
 			Flags:     updateNamespaceFlags,
-			ArgsUsage: "[NAMESPACE NAME]",
+			ArgsUsage: "namespace_name [cluster_name...]",
 			Action: func(c *cli.Context) error {
 				return UpdateNamespace(c)
 			},
@@ -108,7 +108,7 @@ func newNamespaceCommands() []*cli.Command {
 			Name:      "delete",
 			Usage:     "Delete existing Namespace",
 			Flags:     deleteNamespacesFlags,
-			ArgsUsage: "[NAMESPACE NAME]",
+			ArgsUsage: "namespace_name",
 			Action: func(c *cli.Context) error {
 				return DeleteNamespace(c)
 			},


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Use args for namespace name instead of global flag for `namespace` command.

## Why?
<!-- Tell your future self why have you made these changes -->
`namespace delete` can't use global flag because in this case it will delete `default` namespace if simple 
```
$ tctl namespace delete
```
is executed.
I changed all other namespace commands for consistency.
