### PR TITLE
Refactor batch stop and describe commands to use API

### DIFF
--- a/cli/batch.go
+++ b/cli/batch.go
@@ -104,8 +104,8 @@ func newBatchCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:  "terminate",
-			Usage: "terminate a batch operation job",
+			Name:  "stop",
+			Usage: "stop a batch operation job",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagJobID,
@@ -119,7 +119,7 @@ func newBatchCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return TerminateBatchJob(c)
+				return StopBatchJob(c)
 			},
 		},
 	}

--- a/cli/batch_commands.go
+++ b/cli/batch_commands.go
@@ -47,10 +47,10 @@ import (
 func DescribeBatchJob(c *cli.Context) error {
 	jobID := c.String(FlagJobID)
 
-	client := cFactory.SDKClient(c, primitives.SystemLocalNamespace)
+	client := cFactory.FrontendClient(c)
 	ctx, cancel := newContext(c)
 	defer cancel()
-	resp, err := client.WorkflowService().DescribeBatchOperation(ctx, &workflowservice.DescribeBatchOperationRequest{
+	resp, err := client.DescribeBatchOperation(ctx, &workflowservice.DescribeBatchOperationRequest{
 		Namespace: primitives.SystemLocalNamespace,
 		JobId:     jobID,
 	})
@@ -201,11 +201,11 @@ func StartBatchJob(c *cli.Context) error {
 func StopBatchJob(c *cli.Context) error {
 	jobID := c.String(FlagJobID)
 	reason := c.String(FlagReason)
-	client := cFactory.SDKClient(c, primitives.SystemLocalNamespace)
+	client := cFactory.FrontendClient(c)
 
 	ctx, cancel := newContext(c)
 	defer cancel()
-	_, err := client.WorkflowService().StopBatchOperation(ctx, &workflowservice.StopBatchOperationRequest{
+	_, err := client.StopBatchOperation(ctx, &workflowservice.StopBatchOperationRequest{
 		Namespace: primitives.SystemLocalNamespace,
 		JobId:     jobID,
 		Reason:    reason,

--- a/cli/batch_commands.go
+++ b/cli/batch_commands.go
@@ -30,16 +30,15 @@ import (
 	"os"
 	"strings"
 
+	"github.com/temporalio/tctl-kit/pkg/color"
 	"github.com/temporalio/tctl-kit/pkg/output"
 	"github.com/temporalio/tctl-kit/pkg/pager"
 	"github.com/urfave/cli/v2"
-	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/server/common/collection"
-	"go.temporal.io/server/common/primitives"
-
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service/worker/batcher"
 )
@@ -49,33 +48,22 @@ func DescribeBatchJob(c *cli.Context) error {
 	jobID := c.String(FlagJobID)
 
 	client := cFactory.SDKClient(c, primitives.SystemLocalNamespace)
-	tcCtx, cancel := newContext(c)
+	ctx, cancel := newContext(c)
 	defer cancel()
-	wf, err := client.DescribeWorkflowExecution(tcCtx, jobID, "")
+	resp, err := client.WorkflowService().DescribeBatchOperation(ctx, &workflowservice.DescribeBatchOperationRequest{
+		Namespace: primitives.SystemLocalNamespace,
+		JobId:     jobID,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to describe batch job: %w", err)
 	}
 
-	output := map[string]interface{}{}
-	if wf.WorkflowExecutionInfo.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
-		if wf.WorkflowExecutionInfo.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
-			output["msg"] = "batch job stopped status: " + wf.WorkflowExecutionInfo.GetStatus().String()
-		} else {
-			output["msg"] = "batch job is finished successfully"
-		}
-	} else {
-		output["msg"] = "batch job is running"
-		if len(wf.PendingActivities) > 0 {
-			hbdPayload := wf.PendingActivities[0].HeartbeatDetails
-			var hbd batcher.HeartBeatDetails
-			err := payloads.Decode(hbdPayload, &hbd)
-			if err != nil {
-				return fmt.Errorf("failed to describe batch job: %w", err)
-			}
-			output["progress"] = hbd
-		}
+	opts := &output.PrintOptions{
+		Fields:     []string{"State", "JobId", "StartTime"},
+		FieldsLong: []string{"Identity", "Reason"},
+		Pager:      pager.Less,
 	}
-	prettyPrintJSONObject(output)
+	output.PrintItems(c, []interface{}{resp}, opts)
 	return nil
 }
 
@@ -209,21 +197,26 @@ func StartBatchJob(c *cli.Context) error {
 	return nil
 }
 
-// TerminateBatchJob stops abatch job
-func TerminateBatchJob(c *cli.Context) error {
+// StopBatchJob stops a batch job
+func StopBatchJob(c *cli.Context) error {
 	jobID := c.String(FlagJobID)
 	reason := c.String(FlagReason)
 	client := cFactory.SDKClient(c, primitives.SystemLocalNamespace)
-	tcCtx, cancel := newContext(c)
+
+	ctx, cancel := newContext(c)
 	defer cancel()
-	err := client.TerminateWorkflow(tcCtx, jobID, "", reason, nil)
+	_, err := client.WorkflowService().StopBatchOperation(ctx, &workflowservice.StopBatchOperationRequest{
+		Namespace: primitives.SystemLocalNamespace,
+		JobId:     jobID,
+		Reason:    reason,
+		Identity:  getCurrentUserFromEnv(),
+	})
+
 	if err != nil {
-		return fmt.Errorf("failed to terminate batch job: %w", err)
+		return fmt.Errorf("unable to stop a batch job %s: %s", color.Magenta(c, jobID), err)
 	}
-	output := map[string]interface{}{
-		"msg": "batch job is terminated",
-	}
-	prettyPrintJSONObject(output)
+
+	fmt.Printf("Batch job %s is stopped\n", color.Magenta(c, jobID))
 	return nil
 }
 

--- a/cli/batch_test.go
+++ b/cli/batch_test.go
@@ -39,3 +39,17 @@ func (s *cliAppSuite) TestListBatchJobs() {
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
+
+func (s *cliAppSuite) TestStopBatchJob() {
+	s.sdkClient.On("WorkflowService().StopWorkflowExecution", mock.Anything, mock.Anything).Return(&workflowservice.StopBatchOperationResponse{}, nil).Once()
+	err := s.app.Run([]string{"", "batch", "stop", "--job-id", "test", "--reason", "test"})
+	s.Nil(err)
+	s.sdkClient.AssertExpectations(s.T())
+}
+
+func (s *cliAppSuite) TestDescribeBatchJob() {
+	s.sdkClient.On("WorkflowService().DescribeBatchJob", mock.Anything, mock.Anything).Return(&workflowservice.DescribeBatchOperationResponse{}, nil).Once()
+	err := s.app.Run([]string{"", "batch", "describe", "--job-id", "test"})
+	s.Nil(err)
+	s.sdkClient.AssertExpectations(s.T())
+}

--- a/cli/batch_test.go
+++ b/cli/batch_test.go
@@ -41,14 +41,14 @@ func (s *cliAppSuite) TestListBatchJobs() {
 }
 
 func (s *cliAppSuite) TestStopBatchJob() {
-	s.sdkClient.On("WorkflowService().StopWorkflowExecution", mock.Anything, mock.Anything).Return(&workflowservice.StopBatchOperationResponse{}, nil).Once()
+	s.frontendClient.EXPECT().StopBatchOperation(gomock.Any(), gomock.Any()).Return(&workflowservice.StopBatchOperationResponse{}, nil).Times(1)
 	err := s.app.Run([]string{"", "batch", "stop", "--job-id", "test", "--reason", "test"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
 
 func (s *cliAppSuite) TestDescribeBatchJob() {
-	s.sdkClient.On("WorkflowService().DescribeBatchJob", mock.Anything, mock.Anything).Return(&workflowservice.DescribeBatchOperationResponse{}, nil).Once()
+	s.frontendClient.EXPECT().DescribeBatchOperation(gomock.Any(), gomock.Any()).Return(&workflowservice.DescribeBatchOperationResponse{}, nil).Times(1)
 	err := s.app.Run([]string{"", "batch", "describe", "--job-id", "test"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Renamed `tctl batch terminate` to `stop` in accordance with API
- `tctl batch stop` now uses official API
- `tctl batch describe` now uses official API

## Why?
<!-- Tell your future self why have you made these changes -->

stabilizing by using the official API

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

manual run + new unit test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
