### PR TITLE
Transform batch start into concrete terminate/.. commands

### DIFF
--- a/cli/batch.go
+++ b/cli/batch.go
@@ -25,28 +25,22 @@
 package cli
 
 import (
-	"strings"
-
 	"github.com/temporalio/tctl-kit/pkg/flags"
 	"github.com/urfave/cli/v2"
-
-	"go.temporal.io/server/service/worker/batcher"
 )
-
-var allBatchTypes = []string{batcher.BatchTypeTerminate, batcher.BatchTypeCancel, batcher.BatchTypeSignal}
 
 func newBatchCommands() []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:  "describe",
 			Usage: "Describe a batch operation job",
-			Flags: []cli.Flag{
+			Flags: append([]cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagJobID,
 					Usage:    "Batch Job Id",
 					Required: true,
 				},
-			},
+			}, flags.FlagsForRendering...),
 			Action: func(c *cli.Context) error {
 				return DescribeBatchJob(c)
 			},
@@ -61,33 +55,19 @@ func newBatchCommands() []*cli.Command {
 			},
 		},
 		{
-			Name:  "start",
-			Usage: "Start a batch operation job",
+			Name:  "terminate",
+			Usage: "Terminate a batch of Workflow Executions",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagQuery,
 					Aliases:  FlagQueryAlias,
-					Usage:    "Specify the Workflow Executions to operate on",
+					Usage:    "Specify the Workflow Executions to operate on. See https://docs.temporal.io/docs/tctl/workflow/list#--query for details",
 					Required: true,
 				},
 				&cli.StringFlag{
 					Name:     FlagReason,
 					Usage:    "Reason to run this batch job",
 					Required: true,
-				},
-				&cli.StringFlag{
-					Name:     FlagType,
-					Usage:    "Batch type: " + strings.Join(allBatchTypes, ","),
-					Required: true,
-				},
-				&cli.StringFlag{
-					Name:  FlagSignalName,
-					Usage: "Required for batch signal",
-				},
-				&cli.StringFlag{
-					Name:    FlagInput,
-					Aliases: FlagInputAlias,
-					Usage:   "Optional input of signal",
 				},
 				&cli.BoolFlag{
 					Name:    FlagYes,
@@ -96,12 +76,37 @@ func newBatchCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return StartBatchJob(c)
+				return BatchTerminate(c)
+			},
+		},
+		{
+			Name:  "cancel",
+			Usage: "Cancel a batch of Workflow Executions",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     FlagQuery,
+					Aliases:  FlagQueryAlias,
+					Usage:    "Specify the Workflow Executions to operate on. See https://docs.temporal.io/docs/tctl/workflow/list#--query for details",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:     FlagReason,
+					Usage:    "Reason to run this batch job",
+					Required: true,
+				},
+				&cli.BoolFlag{
+					Name:    FlagYes,
+					Aliases: FlagYesAlias,
+					Usage:   "Confirm all prompts",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				return BatchCancel(c)
 			},
 		},
 		{
 			Name:  "stop",
-			Usage: "stop a batch operation job",
+			Usage: "Stop a batch operation job",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagJobID,
@@ -110,7 +115,7 @@ func newBatchCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     FlagReason,
-					Usage:    "Reason to stop this batch job",
+					Usage:    "Reason to stop the batch job",
 					Required: true,
 				},
 			},

--- a/cli/batch.go
+++ b/cli/batch.go
@@ -55,6 +55,41 @@ func newBatchCommands() []*cli.Command {
 			},
 		},
 		{
+			Name:  "signal",
+			Usage: "Signal a batch of Workflow Executions",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     FlagQuery,
+					Aliases:  FlagQueryAlias,
+					Usage:    "Specify the Workflow Executions to operate on. See https://docs.temporal.io/docs/tctl/workflow/list#--query for details",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:     FlagSignalName,
+					Usage:    "Signal name",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:    FlagInput,
+					Aliases: FlagInputAlias,
+					Usage:   "Input for the signal (JSON)",
+				},
+				&cli.StringFlag{
+					Name:     FlagReason,
+					Usage:    "Reason to signal",
+					Required: true,
+				},
+				&cli.BoolFlag{
+					Name:    FlagYes,
+					Aliases: FlagYesAlias,
+					Usage:   "Confirm all prompts",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				return BatchTerminate(c)
+			},
+		},
+		{
 			Name:  "terminate",
 			Usage: "Terminate a batch of Workflow Executions",
 			Flags: []cli.Flag{
@@ -66,7 +101,7 @@ func newBatchCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     FlagReason,
-					Usage:    "Reason to run this batch job",
+					Usage:    "Reason to terminate",
 					Required: true,
 				},
 				&cli.BoolFlag{
@@ -91,7 +126,7 @@ func newBatchCommands() []*cli.Command {
 				},
 				&cli.StringFlag{
 					Name:     FlagReason,
-					Usage:    "Reason to run this batch job",
+					Usage:    "Reason to cancel",
 					Required: true,
 				},
 				&cli.BoolFlag{

--- a/cli/batch_commands.go
+++ b/cli/batch_commands.go
@@ -26,7 +26,6 @@ package cli
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pborman/uuid"
 	"github.com/temporalio/tctl-kit/pkg/color"
@@ -37,19 +36,21 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/payloads"
-	"go.temporal.io/server/common/primitives"
-	"go.temporal.io/server/service/worker/batcher"
 )
 
 // DescribeBatchJob describe the status of the batch job
 func DescribeBatchJob(c *cli.Context) error {
+	namespace, err := getRequiredGlobalOption(c, FlagNamespace)
+	if err != nil {
+		return err
+	}
 	jobID := c.String(FlagJobID)
 
 	client := cFactory.FrontendClient(c)
 	ctx, cancel := newContext(c)
 	defer cancel()
 	resp, err := client.DescribeBatchOperation(ctx, &workflowservice.DescribeBatchOperationRequest{
-		Namespace: primitives.SystemLocalNamespace,
+		Namespace: namespace,
 		JobId:     jobID,
 	})
 	if err != nil {
@@ -67,6 +68,10 @@ func DescribeBatchJob(c *cli.Context) error {
 
 // ListBatchJobs list the started batch jobs
 func ListBatchJobs(c *cli.Context) error {
+	namespace, err := getRequiredGlobalOption(c, FlagNamespace)
+	if err != nil {
+		return err
+	}
 	client := cFactory.FrontendClient(c)
 
 	paginationFunc := func(npt []byte) ([]interface{}, []byte, error) {
@@ -76,7 +81,7 @@ func ListBatchJobs(c *cli.Context) error {
 		ctx, cancel := newContext(c)
 		defer cancel()
 		resp, err := client.ListBatchOperations(ctx, &workflowservice.ListBatchOperationsRequest{
-			Namespace: primitives.SystemLocalNamespace,
+			Namespace: namespace,
 		})
 
 		for _, e := range resp.OperationInfo {
@@ -99,21 +104,78 @@ func ListBatchJobs(c *cli.Context) error {
 	return output.PrintIterator(c, iter, opts)
 }
 
-// StartBatchJob starts a batch job
-func StartBatchJob(c *cli.Context) error {
+// BatchTerminate terminate a list of workflows
+func BatchTerminate(c *cli.Context) error {
+	operator := getCurrentUserFromEnv()
+
+	req := workflowservice.StartBatchOperationRequest{
+		Operation: &workflowservice.StartBatchOperationRequest_TerminationOperation{
+			TerminationOperation: &batch.BatchOperationTermination{
+				Identity: operator,
+			},
+		},
+	}
+
+	return startBatchJob(c, &req)
+}
+
+// BatchCancel cancel a list of workflows
+func BatchCancel(c *cli.Context) error {
+	operator := getCurrentUserFromEnv()
+
+	req := workflowservice.StartBatchOperationRequest{
+		Operation: &workflowservice.StartBatchOperationRequest_CancellationOperation{
+			CancellationOperation: &batch.BatchOperationCancellation{
+				Identity: operator,
+			},
+		},
+	}
+
+	return startBatchJob(c, &req)
+}
+
+// BatchSignal send a signal to a list of workflows
+func BatchSignal(c *cli.Context) error {
+	operator := getCurrentUserFromEnv()
+
+	signalName := c.String(FlagSignalName)
+	if signalName == "" {
+		return fmt.Errorf("signal name is required")
+	}
+
+	input := c.String(FlagInput)
+
+	inputP, err := payloads.Encode(input)
+	if err != nil {
+		return fmt.Errorf("unable to serialize signal input: %w", err)
+	}
+
+	req := workflowservice.StartBatchOperationRequest{
+		Operation: &workflowservice.StartBatchOperationRequest_SignalOperation{
+			SignalOperation: &batch.BatchOperationSignal{
+				Signal:   signalName,
+				Identity: operator,
+				Input:    inputP,
+			},
+		},
+	}
+
+	return startBatchJob(c, &req)
+}
+
+// startBatchJob starts a batch job
+func startBatchJob(c *cli.Context, req *workflowservice.StartBatchOperationRequest) error {
 	namespace, err := getRequiredGlobalOption(c, FlagNamespace)
 	if err != nil {
 		return err
 	}
 	query := c.String(FlagQuery)
 	reason := c.String(FlagReason)
-	batchType := c.String(FlagType)
-	operator := getCurrentUserFromEnv()
 
 	sdk := cFactory.SDKClient(c, namespace)
 	tcCtx, cancel := newContext(c)
 	defer cancel()
-	cResp, err := sdk.CountWorkflow(tcCtx, &workflowservice.CountWorkflowExecutionsRequest{
+	count, err := sdk.CountWorkflow(tcCtx, &workflowservice.CountWorkflowExecutionsRequest{
 		Namespace: namespace,
 		Query:     query,
 	})
@@ -123,61 +185,22 @@ func StartBatchJob(c *cli.Context) error {
 
 	promptMsg := fmt.Sprintf(
 		"Will start a batch job operating on %v Workflow Executions. Continue? Y/N",
-		color.Yellow(c, "%v", cResp.GetCount()),
+		color.Yellow(c, "%v", count.GetCount()),
 	)
 	if !promptYes(promptMsg, c.Bool(FlagYes)) {
 		return nil
 	}
 
-	input := c.String(FlagInput)
-	payloads, err := payloads.Encode(input)
-	if err != nil {
-		return fmt.Errorf("failed to serialize signal value: %w", err)
-	}
-
 	jobID := uuid.New()
-	req := workflowservice.StartBatchOperationRequest{
-		Namespace:       namespace,
-		Reason:          reason,
-		VisibilityQuery: query,
-		JobId:           jobID,
-	}
-
-	switch batchType {
-	case batcher.BatchTypeSignal:
-		sigName := c.String(FlagSignalName)
-
-		if sigName == "" {
-			return fmt.Errorf("option %s are required for type %s", FlagSignalName, batcher.BatchTypeSignal)
-		}
-
-		req.Operation = &workflowservice.StartBatchOperationRequest_SignalOperation{
-			SignalOperation: &batch.BatchOperationSignal{
-				Signal:   sigName,
-				Input:    payloads,
-				Identity: operator,
-			},
-		}
-	case batcher.BatchTypeTerminate:
-		req.Operation = &workflowservice.StartBatchOperationRequest_TerminationOperation{
-			TerminationOperation: &batch.BatchOperationTermination{
-				Identity: operator,
-			},
-		}
-	case batcher.BatchTypeCancel:
-		req.Operation = &workflowservice.StartBatchOperationRequest_CancellationOperation{
-			CancellationOperation: &batch.BatchOperationCancellation{
-				Identity: operator,
-			},
-		}
-	default:
-		return fmt.Errorf("unknown batch type. Supported types: %s", strings.Join(allBatchTypes, ","))
-	}
+	req.JobId = jobID
+	req.Namespace = namespace
+	req.VisibilityQuery = query
+	req.Reason = reason
 
 	client := cFactory.FrontendClient(c)
 	ctx, cancel := newContext(c)
 	defer cancel()
-	_, err = client.StartBatchOperation(ctx, &req)
+	_, err = client.StartBatchOperation(ctx, req)
 	if err != nil {
 		return fmt.Errorf("unable to start batch job: %s", err)
 	}
@@ -188,14 +211,18 @@ func StartBatchJob(c *cli.Context) error {
 
 // StopBatchJob stops a batch job
 func StopBatchJob(c *cli.Context) error {
+	namespace, err := getRequiredGlobalOption(c, FlagNamespace)
+	if err != nil {
+		return err
+	}
 	jobID := c.String(FlagJobID)
 	reason := c.String(FlagReason)
 	client := cFactory.FrontendClient(c)
 
 	ctx, cancel := newContext(c)
 	defer cancel()
-	_, err := client.StopBatchOperation(ctx, &workflowservice.StopBatchOperationRequest{
-		Namespace: primitives.SystemLocalNamespace,
+	_, err = client.StopBatchOperation(ctx, &workflowservice.StopBatchOperationRequest{
+		Namespace: namespace,
 		JobId:     jobID,
 		Reason:    reason,
 		Identity:  getCurrentUserFromEnv(),

--- a/cli/batch_commands.go
+++ b/cli/batch_commands.go
@@ -136,14 +136,9 @@ func BatchCancel(c *cli.Context) error {
 
 // BatchSignal send a signal to a list of workflows
 func BatchSignal(c *cli.Context) error {
-	operator := getCurrentUserFromEnv()
-
 	signalName := c.String(FlagSignalName)
-	if signalName == "" {
-		return fmt.Errorf("signal name is required")
-	}
-
 	input := c.String(FlagInput)
+	operator := getCurrentUserFromEnv()
 
 	inputP, err := payloads.Encode(input)
 	if err != nil {

--- a/cli/batch_test.go
+++ b/cli/batch_test.go
@@ -58,7 +58,7 @@ func (s *cliAppSuite) TestDescribeBatchJob() {
 func (s *cliAppSuite) TestStartBatchJob_Signal() {
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{Count: 5}, nil).Once()
 	s.frontendClient.EXPECT().StartBatchOperation(gomock.Any(), gomock.Any()).Return(&workflowservice.StartBatchOperationResponse{}, nil).Times(1)
-	err := s.app.Run([]string{"", "batch", "start", "--type", "signal", "--query", "WorkflowType='test-type'", "--reason", "test-reason", "--signal-name", "test-signal", "--input", "test-input", "--yes"})
+	err := s.app.Run([]string{"", "batch", "signal", "--query", "WorkflowType='test-type'", "--reason", "test-reason", "--signal-name", "test-signal", "--input", "test-input", "--yes"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
@@ -66,7 +66,7 @@ func (s *cliAppSuite) TestStartBatchJob_Signal() {
 func (s *cliAppSuite) TestStartBatchJob_Terminate() {
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{Count: 5}, nil).Once()
 	s.frontendClient.EXPECT().StartBatchOperation(gomock.Any(), gomock.Any()).Return(&workflowservice.StartBatchOperationResponse{}, nil).Times(1)
-	err := s.app.Run([]string{"", "batch", "start", "--type", "terminate", "--query", "WorkflowType='test-type'", "--reason", "test-reason", "--yes"})
+	err := s.app.Run([]string{"", "batch", "terminate", "--query", "WorkflowType='test-type'", "--reason", "test-reason", "--yes"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
@@ -74,7 +74,7 @@ func (s *cliAppSuite) TestStartBatchJob_Terminate() {
 func (s *cliAppSuite) TestStartBatchJob_Cancel() {
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{Count: 5}, nil).Once()
 	s.frontendClient.EXPECT().StartBatchOperation(gomock.Any(), gomock.Any()).Return(&workflowservice.StartBatchOperationResponse{}, nil).Times(1)
-	err := s.app.Run([]string{"", "batch", "start", "--type", "cancel", "--query", "WorkflowType='test-type'", "--reason", "test-reason", "--yes"})
+	err := s.app.Run([]string{"", "batch", "cancel", "--query", "WorkflowType='test-type'", "--reason", "test-reason", "--yes"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Changed:
* `batch start --batch-type terminate` -> `batch terminate`
* `batch start --batch-type cancel` -> `batch cancel`
* `batch start --batch-type signal` -> `batch signal`

## Why?
<!-- Tell your future self why have you made these changes -->

easier to type / discover

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Updated unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
