### PR TITLE
Do not prompt on config error

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -25,11 +25,9 @@
 package cli
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"runtime/debug"
-	"strings"
 
 	"github.com/urfave/cli/v2"
 
@@ -147,13 +145,7 @@ func NewCliApp() *cli.App {
 		SetFactory(NewClientFactory())
 	}
 
-	if tctlConfig == nil {
-		var err error
-		if tctlConfig, err = config.NewTctlConfig(); err != nil {
-			fmt.Printf("unable to load tctl config: %v", err)
-			promptContinueWithoutConfig()
-		}
-	}
+	tctlConfig, _ = config.NewTctlConfig()
 	populateFlags(app.Commands, app.Flags)
 	useDynamicCommands(app)
 
@@ -217,20 +209,4 @@ func handleError(c *cli.Context, err error) {
 	}
 
 	cli.OsExiter(1)
-}
-
-func promptContinueWithoutConfig() {
-	reader := bufio.NewReader(os.Stdin)
-	for {
-		fmt.Print("do you want to continue without reading from tctl config[Yes/No]:")
-		text, err := reader.ReadString('\n')
-		if err != nil {
-			fmt.Printf("unable to confirm: %s", err)
-		}
-		if strings.EqualFold(strings.TrimSpace(text), "yes") {
-			break
-		} else {
-			fmt.Println("command is canceled")
-		}
-	}
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Removed the prompt asking whether to continue w/o config loaded

## Why?
<!-- Tell your future self why have you made these changes -->

the prompt would result in a stuck experience in cicds (where config feature also unlikely to be used, and if it is, the values will fallback to default namespace and default values)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
