### PR TITLE
Transform multi-value flags into slice flags

### DIFF
--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -128,25 +128,25 @@ func (s *cliAppSuite) TestAppCommands() {
 
 func (s *cliAppSuite) TestNamespaceRegister_LocalNamespace() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
-	err := s.app.Run([]string{"", "namespace", "register", "--global-namespace", "false", cliTestNamespace})
+	err := s.app.Run([]string{"", "namespace", "register", "--global", "false", cliTestNamespace})
 	s.NoError(err)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_GlobalNamespace() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
-	err := s.app.Run([]string{"", "namespace", "register", "--global-namespace", "true", cliTestNamespace})
+	err := s.app.Run([]string{"", "namespace", "register", "--global", "true", cliTestNamespace})
 	s.NoError(err)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_NamespaceExist() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceAlreadyExists(""))
-	errorCode := s.RunWithExitCode([]string{"", "namespace", "register", "--global-namespace", "true", cliTestNamespace})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "register", "--global", "true", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestNamespaceRegister_Failed() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.RunWithExitCode([]string{"", "namespace", "register", "--global-namespace", "true", cliTestNamespace})
+	errorCode := s.RunWithExitCode([]string{"", "namespace", "register", "--global", "true", cliTestNamespace})
 	s.Equal(1, errorCode)
 }
 
@@ -178,7 +178,7 @@ func (s *cliAppSuite) TestNamespaceUpdate() {
 	s.frontendClient.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 	err := s.app.Run([]string{"", "namespace", "update", cliTestNamespace})
 	s.Nil(err)
-	err = s.app.Run([]string{"", "namespace", "update", "--description", "another desc", "--owner-email", "another@uber.com", "--retention", "1", cliTestNamespace})
+	err = s.app.Run([]string{"", "namespace", "update", "--description", "another desc", "--email", "another@uber.com", "--retention", "1", cliTestNamespace})
 	s.Nil(err)
 }
 
@@ -365,13 +365,13 @@ func (s *cliAppSuite) TestCancelWorkflow_Failed() {
 
 func (s *cliAppSuite) TestSignalWorkflow() {
 	s.frontendClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, nil)
-	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "signal", "--workflow-id", "wid", "--name", "signal-name"})
+	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "signal", "--name", "signal-name", "--workflow-id", "wid"})
 	s.Nil(err)
 }
 
 func (s *cliAppSuite) TestSignalWorkflow_Failed() {
 	s.frontendClient.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewInvalidArgument("faked error"))
-	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "workflow", "signal", "--workflow-id", "wid", "--name", "signal-name"})
+	errorCode := s.RunWithExitCode([]string{"", "--namespace", cliTestNamespace, "workflow", "signal", "--name", "signal-name", "--workflow-id", "wid"})
 	s.Equal(1, errorCode)
 }
 

--- a/cli/batch.go
+++ b/cli/batch.go
@@ -65,7 +65,7 @@ func newBatchCommands() []*cli.Command {
 					Required: true,
 				},
 				&cli.StringFlag{
-					Name:     FlagSignalName,
+					Name:     FlagName,
 					Usage:    "Signal name",
 					Required: true,
 				},

--- a/cli/batch_commands.go
+++ b/cli/batch_commands.go
@@ -135,7 +135,7 @@ func BatchCancel(c *cli.Context) error {
 
 // BatchSignal send a signal to a list of workflows
 func BatchSignal(c *cli.Context) error {
-	signalName := c.String(FlagSignalName)
+	signalName := c.String(FlagName)
 	input := c.String(FlagInput)
 	operator := getCurrentUserFromEnv()
 

--- a/cli/batch_test.go
+++ b/cli/batch_test.go
@@ -58,7 +58,7 @@ func (s *cliAppSuite) TestDescribeBatchJob() {
 func (s *cliAppSuite) TestStartBatchJob_Signal() {
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{Count: 5}, nil).Once()
 	s.frontendClient.EXPECT().StartBatchOperation(gomock.Any(), gomock.Any()).Return(&workflowservice.StartBatchOperationResponse{}, nil).Times(1)
-	err := s.app.Run([]string{"", "batch", "signal", "--query", "WorkflowType='test-type'", "--reason", "test-reason", "--signal-name", "test-signal", "--input", "test-input", "--yes"})
+	err := s.app.Run([]string{"", "batch", "signal", "--name", "test-signal", "--query", "WorkflowType='test-type'", "--reason", "test-reason", "--input", "test-input", "--yes"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -33,9 +33,6 @@ import (
 
 // Flags used to specify cli command line arguments
 var (
-	FlagUsername                   = "username"
-	FlagPassword                   = "password"
-	FlagKeyspace                   = "keyspace"
 	FlagAddress                    = "address"
 	FlagAuth                       = "auth"
 	FlagNamespaceID                = "namespace-id"
@@ -48,9 +45,8 @@ var (
 	FlagTaskQueue                  = "task-queue"
 	FlagTaskQueueAlias             = []string{"t"}
 	FlagTaskQueueType              = "task-queue-type"
-	FlagWorkflowIDReusePolicy      = "workflow-id-reuse-policy"
+	FlagWorkflowIDReusePolicy      = "id-reuse-policy"
 	FlagCronSchedule               = "cron"
-	FlagWorkflowType               = "type"
 	FlagWorkflowExecutionTimeout   = "execution-timeout"
 	FlagWorkflowRunTimeout         = "run-timeout"
 	FlagWorkflowTaskTimeout        = "task-timeout"
@@ -65,15 +61,13 @@ var (
 	FlagSkipBaseIsNotCurrent       = "skip-base-is-not-current"
 	FlagDryRun                     = "dry-run"
 	FlagNonDeterministic           = "non-deterministic"
-	FlagCluster                    = "cluster"
 	FlagResult                     = "result"
 	FlagIdentity                   = "identity"
 	FlagDetail                     = "detail"
 	FlagReason                     = "reason"
-	FlagPageSize                   = "pagesize"
 	FlagPrintRaw                   = "raw"
 	FlagDescription                = "description"
-	FlagOwnerEmail                 = "owner-email"
+	FlagOwnerEmail                 = "email"
 	FlagRetention                  = "retention"
 	FlagHistoryArchivalState       = "history-archival-state"
 	FlagHistoryArchivalURI         = "history-uri"
@@ -81,13 +75,12 @@ var (
 	FlagVisibilityArchivalURI      = "visibility-uri"
 	FlagName                       = "name"
 	FlagOutputFilename             = "output-filename"
-	FlagQueryType                  = "query-type"
-	FlagQueryRejectCondition       = "query-reject-condition"
+	FlagQueryRejectCondition       = "reject-condition"
 	FlagActiveClusterName          = "active-cluster"
-	FlagClusters                   = "clusters"
-	FlagIsGlobalNamespace          = "global-namespace"
-	FlagNamespaceData              = "namespace-data"
-	FlagPromoteNamespace           = "promote-namespace"
+	FlagCluster                    = "cluster"
+	FlagNamespaceData              = "data"
+	FlagIsGlobalNamespace          = "global"
+	FlagPromoteNamespace           = "promote-global"
 	FlagEventID                    = "event-id"
 	FlagActivityID                 = "activity-id"
 	FlagMaxFieldLength             = "max-field-length"
@@ -106,7 +99,6 @@ var (
 	FlagQueryAlias                 = []string{"q"}
 	FlagQueryUsage                 = "Filter results using SQL like query. See https://docs.temporal.io/docs/tctl/workflow/list#--query for details"
 	FlagArchive                    = "archived"
-	FlagSignalName                 = "signal-name"
 	FlagRPS                        = "rps"
 	FlagJobID                      = "job-id"
 	FlagYes                        = "yes"
@@ -120,7 +112,7 @@ var (
 	FlagDataConverterPlugin        = "data-converter-plugin"
 	FlagCodecAuth                  = "codec-auth"
 	FlagCodecEndpoint              = "codec-endpoint"
-	FlagWebURL                     = "web-ui-url"
+	FlagWebURL                     = "url"
 	FlagHeadersProviderPlugin      = "headers-provider-plugin"
 	FlagPort                       = "port"
 	FlagFollowAlias                = []string{"f"}
@@ -134,8 +126,7 @@ var (
 	FlagEndTime                    = "end-time"
 	FlagJitter                     = "jitter"
 	FlagTimeZone                   = "time-zone"
-	FlagInitialNotes               = "initial-notes"
-	FlagInitialPaused              = "initial-paused"
+	FlagNotes                      = "notes"
 	FlagRemainingActions           = "remaining-actions"
 	FlagCatchupWindow              = "catchup-window"
 	FlagPauseOnFailure             = "pause-on-failure"
@@ -145,13 +136,6 @@ var (
 	FlagNoFold                     = "no-fold"
 	FlagDepth                      = "depth"
 	FlagOutputAlias                = []string{"o"}
-
-	FlagProtoType  = "type"
-	FlagHexData    = "hex-data"
-	FlagHexFile    = "hex-file"
-	FlagBinaryFile = "binary-file"
-	FlagBase64Data = "base64-data"
-	FlagBase64File = "base64-file"
 )
 
 var flagsForExecution = []cli.Flag{
@@ -203,7 +187,7 @@ var flagsForStartWorkflow = []cli.Flag{
 		Required: true,
 	},
 	&cli.StringFlag{
-		Name:     FlagWorkflowType,
+		Name:     FlagType,
 		Usage:    "Workflow type name",
 		Required: true,
 	},

--- a/cli/namespace.go
+++ b/cli/namespace.go
@@ -40,23 +40,21 @@ func SetRequiredNamespaceDataKeys(keys []string) {
 }
 
 func checkRequiredNamespaceDataKVs(namespaceData map[string]string) error {
-	// check requiredNamespaceDataKeys
 	for _, k := range requiredNamespaceDataKeys {
 		_, ok := namespaceData[k]
 		if !ok {
-			return fmt.Errorf("namespace data error, missing required key %v . All required keys: %v", k, requiredNamespaceDataKeys)
+			return fmt.Errorf("missing namespace data key %v. Required keys: %v", k, requiredNamespaceDataKeys)
 		}
 	}
 	return nil
 }
 
-func parseNamespaceDataKVs(namespaceDataStr string) (map[string]string, error) {
-	kvstrs := strings.Split(namespaceDataStr, ",")
+func parseNamespaceDataKVs(kvstrs []string) (map[string]string, error) {
 	kvMap := map[string]string{}
 	for _, kvstr := range kvstrs {
 		kv := strings.Split(kvstr, ":")
 		if len(kv) != 2 {
-			return kvMap, fmt.Errorf("namespace data format error. It must be k1:v2,k2:v2,...,kn:vn")
+			return kvMap, fmt.Errorf("unable to parse %s. Expected format: --%s k1:v1 --%s k2:v2", FlagNamespaceData, FlagNamespaceData, FlagNamespaceData)
 		}
 		k := strings.TrimSpace(kv[0])
 		v := strings.TrimSpace(kv[1])

--- a/cli/namespace_commands.go
+++ b/cli/namespace_commands.go
@@ -90,8 +90,8 @@ func RegisterNamespace(c *cli.Context) error {
 	}
 
 	var clusters []*replicationpb.ClusterReplicationConfig
-	if c.IsSet(FlagClusters) {
-		clusterStr := c.String(FlagClusters)
+	if c.IsSet(FlagCluster) {
+		clusterStr := c.String(FlagCluster)
 		clusters = append(clusters, &replicationpb.ClusterReplicationConfig{
 			ClusterName: clusterStr,
 		})
@@ -210,8 +210,8 @@ func UpdateNamespace(c *cli.Context) error {
 				return fmt.Errorf("option %s format is invalid: %w", FlagRetention, err)
 			}
 		}
-		if c.IsSet(FlagClusters) {
-			clusterStr := c.String(FlagClusters)
+		if c.IsSet(FlagCluster) {
+			clusterStr := c.String(FlagCluster)
 			clusters = append(clusters, &replicationpb.ClusterReplicationConfig{
 				ClusterName: clusterStr,
 			})

--- a/cli/namespace_utils.go
+++ b/cli/namespace_utils.go
@@ -50,7 +50,7 @@ var (
 			// use StringFlag instead of buggy StringSliceFlag
 			// TODO when https://github.com/urfave/cli/pull/392 & v2 is released
 			//  consider update urfave/cli
-			Name:  FlagClusters,
+			Name:  FlagCluster,
 			Usage: "Clusters",
 		},
 		&cli.StringFlag{
@@ -100,7 +100,7 @@ var (
 			// use StringFlag instead of buggy StringSliceFlag
 			// TODO when https://github.com/urfave/cli/pull/392 & v2 is released
 			//  consider update urfave/cli
-			Name:  FlagClusters,
+			Name:  FlagCluster,
 			Usage: "Clusters",
 		},
 		&cli.StringFlag{

--- a/cli/namespace_utils.go
+++ b/cli/namespace_utils.go
@@ -46,10 +46,7 @@ var (
 			Name:  FlagActiveClusterName,
 			Usage: "Active cluster name",
 		},
-		&cli.StringFlag{
-			// use StringFlag instead of buggy StringSliceFlag
-			// TODO when https://github.com/urfave/cli/pull/392 & v2 is released
-			//  consider update urfave/cli
+		&cli.StringSliceFlag{
 			Name:  FlagCluster,
 			Usage: "Clusters",
 		},
@@ -57,7 +54,7 @@ var (
 			Name:  FlagIsGlobalNamespace,
 			Usage: "Flag to indicate whether namespace is a global namespace",
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:  FlagNamespaceData,
 			Usage: "Namespace data of key value pairs, in format of k1:v1,k2:v2,k3:v3",
 		},
@@ -97,13 +94,10 @@ var (
 			Usage: "Active cluster name",
 		},
 		&cli.StringFlag{
-			// use StringFlag instead of buggy StringSliceFlag
-			// TODO when https://github.com/urfave/cli/pull/392 & v2 is released
-			//  consider update urfave/cli
 			Name:  FlagCluster,
 			Usage: "Clusters",
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:  FlagNamespaceData,
 			Usage: "Namespace data of key value pairs, in format of k1:v1,k2:v2,k3:v3 ",
 		},

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -76,11 +76,11 @@ func newScheduleCommands() []*cli.Command {
 
 	scheduleStateFlags := []cli.Flag{
 		&cli.StringFlag{
-			Name:  FlagInitialNotes,
+			Name:  FlagNotes,
 			Usage: "Initial value of notes field",
 		},
 		&cli.BoolFlag{
-			Name:  FlagInitialPaused,
+			Name:  FlagPause,
 			Usage: "Initial value of paused state",
 		},
 		&cli.IntFlag{

--- a/cli/schedule_commands.go
+++ b/cli/schedule_commands.go
@@ -169,8 +169,8 @@ func buildScheduleAction(c *cli.Context) (*schedpb.ScheduleAction, error) {
 
 func buildScheduleState(c *cli.Context) (*schedpb.ScheduleState, error) {
 	var out schedpb.ScheduleState
-	out.Notes = c.String(FlagInitialNotes)
-	out.Paused = c.Bool(FlagInitialPaused)
+	out.Notes = c.String(FlagNotes)
+	out.Paused = c.Bool(FlagPause)
 	if c.IsSet(FlagRemainingActions) {
 		out.LimitedActions = true
 		out.RemainingActions = int64(c.Int(FlagRemainingActions))

--- a/cli/schedule_commands.go
+++ b/cli/schedule_commands.go
@@ -25,7 +25,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -79,7 +78,7 @@ func buildIntervalSpec(s string) (*schedpb.IntervalSpec, error) {
 	var err error
 	parts := strings.Split(s, "/")
 	if len(parts) > 2 {
-		return nil, errors.New("Invalid interval string")
+		return nil, fmt.Errorf("invalid --%s string", FlagInterval)
 	} else if len(parts) == 2 {
 		if phase, err = timestamp.ParseDuration(parts[1]); err != nil {
 			return nil, err
@@ -312,9 +311,9 @@ func ToggleSchedule(c *cli.Context) error {
 
 	pause, unpause := c.Bool(FlagPause), c.Bool(FlagUnpause)
 	if pause && unpause {
-		return errors.New("Cannot specify both --pause and --unpause")
+		return fmt.Errorf("specify either --%s or --%s", FlagPause, FlagUnpause)
 	} else if !pause && !unpause {
-		return errors.New("Must specify one of --pause and --unpause")
+		return fmt.Errorf("specify either --%s or --%s", FlagPause, FlagUnpause)
 	}
 	patch := &schedpb.SchedulePatch{}
 	if pause {

--- a/cli/workflow.go
+++ b/cli/workflow.go
@@ -87,7 +87,7 @@ func newWorkflowCommands() []*cli.Command {
 			Usage: "Query a Workflow Execution",
 			Flags: append(flagsForStackTraceQuery,
 				&cli.StringFlag{
-					Name:     FlagQueryType,
+					Name:     FlagType,
 					Usage:    "The query type you want to run",
 					Required: true,
 				}),

--- a/cli/workflow_commands.go
+++ b/cli/workflow_commands.go
@@ -71,7 +71,7 @@ func startWorkflowBaseArgs(c *cli.Context) (
 	wid string,
 ) {
 	taskQueue = c.String(FlagTaskQueue)
-	workflowType = c.String(FlagWorkflowType)
+	workflowType = c.String(FlagType)
 	et = c.Int(FlagWorkflowExecutionTimeout)
 	rt = c.Int(FlagWorkflowRunTimeout)
 	dt = c.Int(FlagWorkflowTaskTimeout)
@@ -485,7 +485,7 @@ func SignalWorkflow(c *cli.Context) error {
 
 // QueryWorkflow query workflow execution
 func QueryWorkflow(c *cli.Context) error {
-	queryType := c.String(FlagQueryType)
+	queryType := c.String(FlagType)
 
 	if err := queryWorkflowHelper(c, queryType); err != nil {
 		return err


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Transformed namespace `--data` into a slice:
`tctl namespace register --data "k1:v1,k2:v2" -> `tctl namespace register --data k1:v1 --data k2:v2"

Transformed `--cluster + cluster_args` into a slice:
`tctl namespace register --active-cluster cluster1 --cluster cluster1 cluster2` -> `tctl namespace register  --active-cluster cluster1 --cluster cluster1 --cluster cluster2`

## Why?
<!-- Tell your future self why have you made these changes -->

Consistency in how multiple values are provided, similar to `--input`, `--search--attribute`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
