### PR TITLE
Transform Namespace --data into a slice

### DIFF
--- a/cli/namespace.go
+++ b/cli/namespace.go
@@ -25,9 +25,6 @@
 package cli
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/urfave/cli/v2"
 )
 
@@ -37,33 +34,6 @@ var requiredNamespaceDataKeys []string
 // SetRequiredNamespaceDataKeys will set requiredNamespaceDataKeys
 func SetRequiredNamespaceDataKeys(keys []string) {
 	requiredNamespaceDataKeys = keys
-}
-
-func checkRequiredNamespaceDataKVs(namespaceData map[string]string) error {
-	// check requiredNamespaceDataKeys
-	for _, k := range requiredNamespaceDataKeys {
-		_, ok := namespaceData[k]
-		if !ok {
-			return fmt.Errorf("namespace data error, missing required key %v . All required keys: %v", k, requiredNamespaceDataKeys)
-		}
-	}
-	return nil
-}
-
-func parseNamespaceDataKVs(namespaceDataStr string) (map[string]string, error) {
-	kvstrs := strings.Split(namespaceDataStr, ",")
-	kvMap := map[string]string{}
-	for _, kvstr := range kvstrs {
-		kv := strings.Split(kvstr, ":")
-		if len(kv) != 2 {
-			return kvMap, fmt.Errorf("namespace data format error. It must be k1:v2,k2:v2,...,kn:vn")
-		}
-		k := strings.TrimSpace(kv[0])
-		v := strings.TrimSpace(kv[1])
-		kvMap[k] = v
-	}
-
-	return kvMap, nil
 }
 
 func newNamespaceCommands() []*cli.Command {

--- a/cli/namespace_test.go
+++ b/cli/namespace_test.go
@@ -48,6 +48,12 @@ func (s *cliAppSuite) TestNamespaceRegister_GlobalNamespace() {
 	s.NoError(err)
 }
 
+func (s *cliAppSuite) TestNamespaceRegister_Data() {
+	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
+	err := s.app.Run([]string{"", "namespace", "register", "--data", "k1=v1", "--data", "k2=v2", "true", cliTestNamespace})
+	s.NoError(err)
+}
+
 func (s *cliAppSuite) TestNamespaceRegister_NamespaceExist() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceAlreadyExists(""))
 	errorCode := s.RunWithExitCode([]string{"", "namespace", "register", "--global", "true", cliTestNamespace})
@@ -90,6 +96,13 @@ func (s *cliAppSuite) TestNamespaceUpdate() {
 	s.Nil(err)
 	err = s.app.Run([]string{"", "namespace", "update", "--description", "another desc", "--email", "another@uber.com", "--retention", "1", cliTestNamespace})
 	s.Nil(err)
+}
+
+func (s *cliAppSuite) TestNamespaceUpdate_Data() {
+	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(describeNamespaceResponseServer, nil).Times(1)
+	s.frontendClient.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+	err := s.app.Run([]string{"", "namespace", "update", "--data", "k1=v1", "--data", "k2=v2", "true", cliTestNamespace})
+	s.NoError(err)
 }
 
 func (s *cliAppSuite) TestNamespaceUpdate_NamespaceNotExist() {

--- a/cli/namespace_utils.go
+++ b/cli/namespace_utils.go
@@ -57,9 +57,9 @@ var (
 			Name:  FlagIsGlobalNamespace,
 			Usage: "Flag to indicate whether namespace is a global namespace",
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:  FlagNamespaceData,
-			Usage: "Namespace data of key value pairs, in format of k1:v1,k2:v2,k3:v3",
+			Usage: "Namespace data in a format key=value",
 		},
 		&cli.StringFlag{
 			Name:  FlagHistoryArchivalState,
@@ -103,9 +103,9 @@ var (
 			Name:  FlagCluster,
 			Usage: "Clusters",
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:  FlagNamespaceData,
-			Usage: "Namespace data of key value pairs, in format of k1:v1,k2:v2,k3:v3 ",
+			Usage: "Namespace data in a format key=value",
 		},
 		&cli.StringFlag{
 			Name:  FlagHistoryArchivalState,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->


- Changed namespace `--data` key-value separator from `:` to `=`

- Transformed namespace `--data` into a slice:

Example:

before
`tctl namespace register --data k1:v1,k2:v2` 

after
`tctl namespace register --data k1=v1 --data k2=v2`


## Why?
<!-- Tell your future self why have you made these changes -->

Consistency with other multi-value flags  such as `--input`, `--search-attribute`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

added unit test + manual run `tctl namespace register --data k1=v1 --data k2=v2 test1`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
