### PR TITLE
Transform Namespace --cluster + args into a slice

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -76,7 +76,7 @@ var (
 	FlagName                       = "name"
 	FlagOutputFilename             = "output-filename"
 	FlagQueryRejectCondition       = "reject-condition"
-	FlagActiveClusterName          = "active-cluster"
+	FlagActiveCluster              = "active-cluster"
 	FlagCluster                    = "cluster"
 	FlagNamespaceData              = "data"
 	FlagIsGlobalNamespace          = "global"

--- a/cli/namespace_commands.go
+++ b/cli/namespace_commands.go
@@ -85,20 +85,17 @@ func RegisterNamespace(c *cli.Context) error {
 		}
 	}
 
-	var activeClusterName string
-	if c.IsSet(FlagActiveClusterName) {
-		activeClusterName = c.String(FlagActiveClusterName)
+	var activeCluster string
+	if c.IsSet(FlagActiveCluster) {
+		activeCluster = c.String(FlagActiveCluster)
 	}
 
 	var clusters []*replicationpb.ClusterReplicationConfig
 	if c.IsSet(FlagCluster) {
-		clusterStr := c.String(FlagCluster)
-		clusters = append(clusters, &replicationpb.ClusterReplicationConfig{
-			ClusterName: clusterStr,
-		})
-		for _, clusterStr := range c.Args().Slice()[1:] { // First element is namespace name.
+		clusterNames := c.StringSlice(FlagCluster)
+		for _, clusterName := range clusterNames {
 			clusters = append(clusters, &replicationpb.ClusterReplicationConfig{
-				ClusterName: clusterStr,
+				ClusterName: clusterName,
 			})
 		}
 	}
@@ -119,7 +116,7 @@ func RegisterNamespace(c *cli.Context) error {
 		Data:                             data,
 		WorkflowExecutionRetentionPeriod: &retention,
 		Clusters:                         clusters,
-		ActiveClusterName:                activeClusterName,
+		ActiveClusterName:                activeCluster,
 		HistoryArchivalState:             archState,
 		HistoryArchivalUri:               c.String(FlagHistoryArchivalURI),
 		VisibilityArchivalState:          archVisState,
@@ -163,8 +160,8 @@ func UpdateNamespace(c *cli.Context) error {
 			Namespace:        ns,
 			PromoteNamespace: true,
 		}
-	} else if c.IsSet(FlagActiveClusterName) {
-		activeCluster := c.String(FlagActiveClusterName)
+	} else if c.IsSet(FlagActiveCluster) {
+		activeCluster := c.String(FlagActiveCluster)
 		fmt.Printf("Will set active cluster name to: %s, other flag will be omitted.\n", activeCluster)
 		replicationConfig := &replicationpb.NamespaceReplicationConfig{
 			ActiveClusterName: activeCluster,
@@ -189,7 +186,6 @@ func UpdateNamespace(c *cli.Context) error {
 		description := resp.NamespaceInfo.GetDescription()
 		ownerEmail := resp.NamespaceInfo.GetOwnerEmail()
 		retention := timestamp.DurationValue(resp.Config.GetWorkflowExecutionRetentionTtl())
-		var clusters []*replicationpb.ClusterReplicationConfig
 
 		if c.IsSet(FlagDescription) {
 			description = c.String(FlagDescription)
@@ -211,14 +207,12 @@ func UpdateNamespace(c *cli.Context) error {
 				return fmt.Errorf("option %s format is invalid: %w", FlagRetention, err)
 			}
 		}
+		var clusters []*replicationpb.ClusterReplicationConfig
 		if c.IsSet(FlagCluster) {
-			clusterStr := c.String(FlagCluster)
-			clusters = append(clusters, &replicationpb.ClusterReplicationConfig{
-				ClusterName: clusterStr,
-			})
-			for _, clusterStr := range c.Args().Slice()[1:] { // First element is namespace name.
+			clusterNames := c.StringSlice(FlagCluster)
+			for _, clusterName := range clusterNames {
 				clusters = append(clusters, &replicationpb.ClusterReplicationConfig{
-					ClusterName: clusterStr,
+					ClusterName: clusterName,
 				})
 			}
 		}

--- a/cli/namespace_test.go
+++ b/cli/namespace_test.go
@@ -60,6 +60,12 @@ func (s *cliAppSuite) TestNamespaceRegister_NamespaceExist() {
 	s.Equal(1, errorCode)
 }
 
+func (s *cliAppSuite) TestNamespaceRegister_Cluster() {
+	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
+	err := s.app.Run([]string{"", "namespace", "register", "--cluster", "active", "--cluster", "standby", cliTestNamespace})
+	s.NoError(err)
+}
+
 func (s *cliAppSuite) TestNamespaceRegister_Failed() {
 	s.frontendClient.EXPECT().RegisterNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewInvalidArgument("faked error"))
 	errorCode := s.RunWithExitCode([]string{"", "namespace", "register", "--global", "true", cliTestNamespace})
@@ -117,6 +123,14 @@ func (s *cliAppSuite) TestNamespaceUpdate_ActiveClusterFlagNotSet_NamespaceNotEx
 	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	errorCode := s.RunWithExitCode([]string{"", "namespace", "update", cliTestNamespace})
 	s.Equal(1, errorCode)
+}
+
+func (s *cliAppSuite) TestNamespaceUpdate_Cluster() {
+	resp := describeNamespaceResponseServer
+	s.frontendClient.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any()).Return(resp, nil).Times(1)
+	s.frontendClient.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil, nil)
+	err := s.app.Run([]string{"", "namespace", "update", "--cluster", "active", "--cluster", "standby", cliTestNamespace})
+	s.NoError(err)
 }
 
 func (s *cliAppSuite) TestNamespaceUpdate_Failed() {

--- a/cli/namespace_utils.go
+++ b/cli/namespace_utils.go
@@ -43,15 +43,12 @@ var (
 			Usage: "Workflow Execution retention",
 		},
 		&cli.StringFlag{
-			Name:  FlagActiveClusterName,
+			Name:  FlagActiveCluster,
 			Usage: "Active cluster name",
 		},
-		&cli.StringFlag{
-			// use StringFlag instead of buggy StringSliceFlag
-			// TODO when https://github.com/urfave/cli/pull/392 & v2 is released
-			//  consider update urfave/cli
+		&cli.StringSliceFlag{
 			Name:  FlagCluster,
-			Usage: "Clusters",
+			Usage: "Cluster name",
 		},
 		&cli.StringFlag{
 			Name:  FlagIsGlobalNamespace,
@@ -93,15 +90,12 @@ var (
 			Usage: "Workflow Execution retention",
 		},
 		&cli.StringFlag{
-			Name:  FlagActiveClusterName,
+			Name:  FlagActiveCluster,
 			Usage: "Active cluster name",
 		},
 		&cli.StringFlag{
-			// use StringFlag instead of buggy StringSliceFlag
-			// TODO when https://github.com/urfave/cli/pull/392 & v2 is released
-			//  consider update urfave/cli
 			Name:  FlagCluster,
-			Usage: "Clusters",
+			Usage: "Cluster name",
 		},
 		&cli.StringSliceFlag{
 			Name:  FlagNamespaceData,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Changed namespace `--cluster plus cluster args` into a slice

## Why?
<!-- Tell your future self why have you made these changes -->

previous syntax for clusters was pretty ugly. It was requiring to set --cluster to specify just one cluster name, then the `args[1:]` would mean the rest of the cluster (after namespace arg)

before
```
tctl namespace register --cluster active my-namespace standby
```

after
```
tctl namespace register --cluster active --cluster standby my-namespace  
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

added unit test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
