### PR TITLE
Allow key=value flags to have equal in value

### DIFF
--- a/cli/namespace_commands.go
+++ b/cli/namespace_commands.go
@@ -28,7 +28,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/temporalio/tctl-kit/pkg/color"
 	"github.com/temporalio/tctl-kit/pkg/output"
@@ -73,7 +72,7 @@ func RegisterNamespace(c *cli.Context) error {
 	data := map[string]string{}
 	if c.IsSet(FlagNamespaceData) {
 		datas := c.StringSlice(FlagNamespaceData)
-		data, err = parseNamespaceData(datas)
+		data, err = ParseKeyValuePairs(datas)
 		if err != nil {
 			return err
 		}
@@ -196,7 +195,7 @@ func UpdateNamespace(c *cli.Context) error {
 		data := map[string]string{}
 		if c.IsSet(FlagNamespaceData) {
 			datas := c.StringSlice(FlagNamespaceData)
-			data, err = parseNamespaceData(datas)
+			data, err = ParseKeyValuePairs(datas)
 			if err != nil {
 				return err
 			}
@@ -478,19 +477,4 @@ func validateNamespaceDataRequiredKeys(namespaceData map[string]string) error {
 		}
 	}
 	return nil
-}
-
-func parseNamespaceData(kvs []string) (map[string]string, error) {
-	kvMap := map[string]string{}
-	for _, kvstr := range kvs {
-		kv := strings.Split(kvstr, "=")
-		if len(kv) != 2 {
-			return kvMap, fmt.Errorf("unable to parse --%s. Expected format: --%s k1=v1 --%s k2=v2", FlagNamespaceData, FlagNamespaceData, FlagNamespaceData)
-		}
-		k := strings.TrimSpace(kv[0])
-		v := strings.TrimSpace(kv[1])
-		kvMap[k] = v
-	}
-
-	return kvMap, nil
 }

--- a/cli/util.go
+++ b/cli/util.go
@@ -774,3 +774,24 @@ func parseFoldStatusList(flagValue string) ([]enumspb.WorkflowExecutionStatus, e
 	}
 	return statusList, nil
 }
+
+// ParseKeyValuePairs parses key=value pairs
+func ParseKeyValuePairs(kvs []string) (map[string]string, error) {
+	pairs := make(map[string]string, len(kvs))
+	for _, v := range kvs {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("unable to parse key=value pair: %v", v)
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		if key == "" {
+			return nil, fmt.Errorf("empty key is not allowed")
+		}
+
+		pairs[key] = value
+	}
+
+	return pairs, nil
+}

--- a/cli/util.go
+++ b/cli/util.go
@@ -28,6 +28,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -787,7 +788,7 @@ func ParseKeyValuePairs(kvs []string) (map[string]string, error) {
 		value := strings.TrimSpace(parts[1])
 
 		if key == "" {
-			return nil, fmt.Errorf("empty key is not allowed")
+			return nil, errors.New("empty key is not allowed")
 		}
 
 		pairs[key] = value

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -150,3 +150,57 @@ func (s *utilSuite) TestParseFoldStatusList() {
 		})
 	}
 }
+
+func (s *utilSuite) TestParseKeyValuePairs() {
+	tests := map[string]struct {
+		input   []string
+		want    map[string]string
+		wantErr bool
+	}{
+		"simple values": {
+			input: []string{
+				"key1=value1",
+				"key2=value2",
+				"key3=value3=with=equal",
+				"key4=value4:with-symbols",
+				"key5=",
+				`key6={"Auth":{"Enabled":false,"Options":["audience","organization"]},"ShowTemporalSystemNamespace":true}`,
+			},
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3=with=equal",
+				"key4": "value4:with-symbols",
+				"key5": "",
+				"key6": `{"Auth":{"Enabled":false,"Options":["audience","organization"]},"ShowTemporalSystemNamespace":true}`,
+			},
+		},
+		"no values": {
+			input: []string{},
+			want:  map[string]string{},
+		},
+		"empty": {
+			input:   []string{""},
+			wantErr: true,
+		},
+		"no separator": {
+			input:   []string{"key:value"},
+			wantErr: true,
+		},
+		"no key": {
+			input:   []string{"=value"},
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		s.Run(name, func() {
+			got, err := ParseKeyValuePairs(tt.input)
+			if tt.wantErr {
+				s.Error(err)
+			} else {
+				s.Equal(tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Allowed values in `key=value` to contain an equal `=` sign

```
tctl namespace register --data k1=value=with=equal
```

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

added unit test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
