### PR TITLE
Make search attributes and memo follow key=value format

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -84,11 +84,9 @@ var (
 	FlagEventID                    = "event-id"
 	FlagActivityID                 = "activity-id"
 	FlagMaxFieldLength             = "max-field-length"
-	FlagMemoKey                    = "memo-key"
 	FlagMemo                       = "memo"
 	FlagMemoFile                   = "memo-file"
-	FlagSearchAttributeKey         = "search-attribute-key"
-	FlagSearchAttributeValue       = "search-attribute-value"
+	FlagSearchAttribute            = "search-attribute"
 	FlagAddBadBinary               = "add-bad-binary"
 	FlagRemoveBadBinary            = "remove-bad-binary"
 	FlagResetReapplyType           = "reapply-type"
@@ -245,24 +243,16 @@ var flagsForStartWorkflowT = []cli.Flag{
 		Usage: "Maximum length for each attribute field",
 	},
 	&cli.StringSliceFlag{
-		Name:  FlagMemoKey,
-		Usage: "Pass a key for an optional memo",
+		Name:  FlagSearchAttribute,
+		Usage: "Pass Search Attribute in a format key=value. Use valid JSON formats for value",
 	},
 	&cli.StringSliceFlag{
 		Name:  FlagMemo,
-		Usage: "Pass a memo value. A memo is information in JSON format that can be shown when the Workflow is listed",
+		Usage: "Pass a memo in a format key=value. Use valid JSON formats for value",
 	},
 	&cli.StringFlag{
 		Name:  FlagMemoFile,
-		Usage: "Pass information for a memo from a JSON file. If there are multiple values, separate them by newline.",
-	},
-	&cli.StringSliceFlag{
-		Name:  FlagSearchAttributeKey,
-		Usage: "Specify a Search Attribute key. See https://docs.temporal.io/docs/concepts/what-is-a-search-attribute/",
-	},
-	&cli.StringSliceFlag{
-		Name:  FlagSearchAttributeValue,
-		Usage: "Specify a Search Attribute value. If value is an array, use JSON format, such as [\"a\",\"b\"] or [1,2], [\"true\",\"false\"]",
+		Usage: "Pass a memo from a file, where each line follows the format key=value. Use valid JSON formats for value",
 	},
 }
 

--- a/cli/namespace_commands.go
+++ b/cli/namespace_commands.go
@@ -72,7 +72,7 @@ func RegisterNamespace(c *cli.Context) error {
 	data := map[string]string{}
 	if c.IsSet(FlagNamespaceData) {
 		datas := c.StringSlice(FlagNamespaceData)
-		data, err = ParseKeyValuePairs(datas)
+		data, err = SplitKeyValuePairs(datas)
 		if err != nil {
 			return err
 		}
@@ -195,7 +195,7 @@ func UpdateNamespace(c *cli.Context) error {
 		data := map[string]string{}
 		if c.IsSet(FlagNamespaceData) {
 			datas := c.StringSlice(FlagNamespaceData)
-			data, err = ParseKeyValuePairs(datas)
+			data, err = SplitKeyValuePairs(datas)
 			if err != nil {
 				return err
 			}

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -104,24 +104,16 @@ func newScheduleCommands() []*cli.Command {
 	// These are the same flags as for start workflow, but we need to change the Usage to talk about schedules instead of workflows.
 	scheduleVisibilityFlags := []cli.Flag{
 		&cli.StringSliceFlag{
-			Name:  FlagMemoKey,
-			Usage: "Key for an optional memo",
+			Name:  FlagSearchAttribute,
+			Usage: "Set Search Attribute on a schedule. Format: key=value. Use valid JSON formats for value",
 		},
 		&cli.StringSliceFlag{
 			Name:  FlagMemo,
-			Usage: "Memo value to be set on the schedule",
+			Usage: "Set a memo on a schedule. Format: key=value. Use valid JSON formats for value",
 		},
 		&cli.StringFlag{
 			Name:  FlagMemoFile,
-			Usage: "Information for a memo from a JSON file. If there are multiple values, separate them by newline",
-		},
-		&cli.StringSliceFlag{
-			Name:  FlagSearchAttributeKey,
-			Usage: "Search Attribute key to be set on the schedule",
-		},
-		&cli.StringSliceFlag{
-			Name:  FlagSearchAttributeValue,
-			Usage: "Search Attribute value. If value is an array, use JSON format, such as [\"a\",\"b\"] or [1,2], [\"true\",\"false\"]",
+			Usage: "Set a memo from a file. Each line should follow the format key=value. Use valid JSON formats for value",
 		},
 	}
 
@@ -132,8 +124,8 @@ func newScheduleCommands() []*cli.Command {
 	createFlags = append(createFlags, scheduleVisibilityFlags...)
 	createFlags = append(createFlags, removeFlags(flagsForStartWorkflowLong,
 		FlagCronSchedule, FlagWorkflowIDReusePolicy,
-		FlagMemoKey, FlagMemo, FlagMemoFile,
-		FlagSearchAttributeKey, FlagSearchAttributeValue,
+		FlagMemo, FlagMemoFile,
+		FlagSearchAttribute,
 	)...)
 
 	return []*cli.Command{

--- a/cli/util.go
+++ b/cli/util.go
@@ -776,13 +776,13 @@ func parseFoldStatusList(flagValue string) ([]enumspb.WorkflowExecutionStatus, e
 	return statusList, nil
 }
 
-// ParseKeyValuePairs parses key=value pairs
-func ParseKeyValuePairs(kvs []string) (map[string]string, error) {
+// SplitKeyValuePairs parses key=value pairs
+func SplitKeyValuePairs(kvs []string) (map[string]string, error) {
 	pairs := make(map[string]string, len(kvs))
 	for _, v := range kvs {
 		parts := strings.SplitN(v, "=", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("unable to parse key=value pair: %v", v)
+			return nil, fmt.Errorf("unable to split key=value pair: %v", v)
 		}
 		key := strings.TrimSpace(parts[0])
 		value := strings.TrimSpace(parts[1])

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -195,7 +195,7 @@ func (s *utilSuite) TestParseKeyValuePairs() {
 
 	for name, tt := range tests {
 		s.Run(name, func() {
-			got, err := ParseKeyValuePairs(tt.input)
+			got, err := SplitKeyValuePairs(tt.input)
 			if tt.wantErr {
 				s.Error(err)
 			} else {

--- a/cli/workflow_test.go
+++ b/cli/workflow_test.go
@@ -87,7 +87,7 @@ func (s *cliAppSuite) TestStartWorkflow_SearchAttributes() {
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 	// start with basic search attributes
 	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "start", "--task-queue", "testTaskQueue", "--type", "testWorkflowType",
-		"--search-attribute-key", "k1", "--search-attribute-value", "\"v1\"", "--search-attribute-key", "k2", "--search-attribute-value", "\"v2\""})
+		"--search-attribute", "k1=\"v1\"", "--search-attribute", "k2=\"v2\""})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 
@@ -99,8 +99,24 @@ func (s *cliAppSuite) TestStartWorkflow_SearchAttributes() {
 	s.sdkClient.AssertCalled(s.T(), "ExecuteWorkflow", mock.Anything, hasCorrectSearchAttributes, mock.Anything, mock.Anything)
 
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
+}
 
-	// TODO: test json search attributes once we know how to they'll be specified (--search-attribute-json?)
+func (s *cliAppSuite) TestStartWorkflow_Memo() {
+	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
+	// start with basic search attributes
+	err := s.app.Run([]string{"", "--namespace", cliTestNamespace, "workflow", "start", "--task-queue", "testTaskQueue", "--type", "testWorkflowType",
+		"--memo", "k1=\"v1\"", "--memo", "k2=\"v2\""})
+	s.Nil(err)
+	s.sdkClient.AssertExpectations(s.T())
+
+	hasCorrectMemo := mock.MatchedBy(func(options sdkclient.StartWorkflowOptions) bool {
+		return len(options.Memo) == 2 &&
+			options.Memo["k1"] == "v1" &&
+			options.Memo["k2"] == "v2"
+	})
+	s.sdkClient.AssertCalled(s.T(), "ExecuteWorkflow", mock.Anything, hasCorrectMemo, mock.Anything, mock.Anything)
+
+	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 }
 
 func (s *cliAppSuite) TestStartWorkflow_Failed() {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Search Attributes and Memo are now expected to be passed as `key=value` instead of separate key and value flags
- Made memo accept both --memo and --memo-file at a time

## Why?
<!-- Tell your future self why have you made these changes -->

typing experience

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
