### PR TITLE
Add new line when printing current env

### DIFF
--- a/cli/env.go
+++ b/cli/env.go
@@ -81,7 +81,7 @@ func newEnvCommands() []*cli.Command {
 }
 
 func CurrentEnv(c *cli.Context) error {
-	fmt.Print(tctlConfig.CurrentEnv)
+	fmt.Println(tctlConfig.CurrentEnv)
 
 	return nil
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

It was missing a newline, which resulted in merging stdout with shell prompt:

```
tctl config current-env                                                                                                                                                                             
ruslan% 
```

## Why?
<!-- Tell your future self why have you made these changes -->

ux

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
