### PR TITLE
Remove unnecessary --raw flag in schedule describe

### DIFF
--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -197,10 +197,6 @@ func newScheduleCommands() []*cli.Command {
 			Usage: "Get schedule configuration and current state",
 			Flags: append([]cli.Flag{
 				sid,
-				&cli.BoolFlag{
-					Name:  FlagPrintRaw,
-					Usage: "Print raw data as json (prefer this over -o json for scripting)",
-				},
 			}, flags.FlagsForRendering...),
 			Action: DescribeSchedule,
 		},

--- a/cli/schedule_commands.go
+++ b/cli/schedule_commands.go
@@ -435,11 +435,6 @@ func DescribeSchedule(c *cli.Context) error {
 		return fmt.Errorf("unable to describe schedule: %w", err)
 	}
 
-	if c.Bool(FlagPrintRaw) {
-		prettyPrintJSONObject(resp)
-		return nil
-	}
-
 	// output.PrintItems gets confused by nested fields of nil values, because it uses
 	// reflection. ensure the first level is non-nil to avoid runtime errors.
 	ensureNonNil(&resp.Schedule)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Removed `--raw` flag in `schedule describe`

## Why?
<!-- Tell your future self why have you made these changes -->

tctl v2 API allows to print JSON objects (raw) automatically by standardized `--output json`


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

```
tctl schedule describe -s 111 --output json

[
  {
    "ScheduleId": "111",
    "Specification": {
      "calendar": [
        {
          "second": "0",
...
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
