### PR TITLE
change syscall.Exec for command.Run to avoid a complete replacement of the current Go process with another

### DIFF
--- a/cli/plugin.go
+++ b/cli/plugin.go
@@ -25,11 +25,17 @@
 package cli
 
 import (
-	"syscall"
+	"os"
+	"os/exec"
 
 	"github.com/urfave/cli/v2"
 )
 
 func executePlugin(ctx *cli.Context, binPath string, args []string, envs []string) error {
-	return syscall.Exec(binPath, args, envs)
+	cmd := exec.CommandContext(ctx.Context, binPath, args...)
+	cmd.Env = envs
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }

--- a/cli/use_dynamic_commands.go
+++ b/cli/use_dynamic_commands.go
@@ -45,7 +45,9 @@ func useDynamicCommands(app *cli.App) {
 		path, err := exec.LookPath(pluginName)
 		if err == nil {
 			os.Args = append([]string{pluginName}, os.Args[2:]...)
-			_ = executePlugin(ctx, path, os.Args, os.Environ())
+			if err := executePlugin(ctx, path, os.Args, os.Environ()); err != nil {
+				fmt.Fprintf(os.Stderr, "unable to complete plugin execution\n%s\n", err)
+			}
 		}
 
 		fmt.Fprintf(os.Stderr, "%s is not a command. See '%s --help\n'", cmdToFind, ctx.App.Name)


### PR DESCRIPTION
## What was changed

change syscall.Exec for command.Run to avoid a complete replacement of the current Go process with another for external plugin execution.

Fixes https://github.com/temporalio/tctl/issues/321

## Why?

If I register a headers provider plugin, this plugin will be spawn and started. Then I execute an external plugin, the current code will replace the current Go process with another by calling syscall.Exec. The side effect is that the app.After will never be called and the header provide plugin will stay and will not be stopped

## Checklist
1. Closes  
https://github.com/temporalio/tctl/issues/321

2. How was this tested

export TEMPORAL_CLI_PLUGIN_HEADERS_PROVIDER=tctl-authorization
tctl yo
check that tctl-authorization is not running anymore

3. Any docs updates needed
