### PR TITLE
fix syntax on `tctl config set` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This will create a configuration file (`~/.config/temporalio/tctl.yaml`) and set
 To switch back to the stable v1.16, run
 
 ```
-tctl config set --version current
+tctl config set version current
 ```
 
 ## License


### PR DESCRIPTION
Config key for version is just `version`, sans --

Tested by copying command from readme, getting a CLI parse error, then removing the `--` to  get expected behavior.