### PR TITLE
Avoid printing that the plugin is not found when it was

### DIFF
--- a/cli/use_dynamic_commands.go
+++ b/cli/use_dynamic_commands.go
@@ -48,6 +48,7 @@ func useDynamicCommands(app *cli.App) {
 			if err := executePlugin(ctx, path, os.Args, os.Environ()); err != nil {
 				fmt.Fprintf(os.Stderr, "unable to complete plugin execution\n%s\n", err)
 			}
+			return
 		}
 
 		fmt.Fprintf(os.Stderr, "%s is not a command. See '%s --help\n'", cmdToFind, ctx.App.Name)


### PR DESCRIPTION
## What was changed
After asuccesful external plugin execution the current code will print that the command is not found.
Add a simple return to avoid this print
