### PR TITLE
Deprecate batch command in favor of API version

### DIFF
--- a/cli_curr/app.go
+++ b/cli_curr/app.go
@@ -162,12 +162,12 @@ func NewCliApp() *cli.App {
 		},
 		{
 			Name:        "batch",
-			Usage:       "Batch operation on a list of workflows from query",
+			Usage:       "Batch operation on a list of workflows from query (deprecated)",
 			Subcommands: newBatchCommands(),
 		},
 		{
 			Name:        "batch-v2",
-			Usage:       "Batch operation on a list of workflows from query",
+			Usage:       "Operate on batch jobs. Use workflow commands with --query flag to start batch job",
 			Subcommands: newBatchV2Commands(),
 		},
 		{


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added a deprecation notion to `tctl batch`

## Why?
<!-- Tell your future self why have you made these changes -->

there is a new `tctl batch-v2` entry for batch commands

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
