### PR TITLE
Fix --namespace_id option for tctl admin workflow command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,6 +68,19 @@
       ]
     },
     {
+      "name": "temporalite:admin:workflow:show",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/tctl",
+      "cwd": "${workspaceFolder}",
+      "args": [
+        "admin",
+        "wf",
+        "show"
+      ]
+    },
+    {
       "name": "temporalite:debug",
       "type": "go",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,19 +68,6 @@
       ]
     },
     {
-      "name": "temporalite:admin:workflow:show",
-      "type": "go",
-      "request": "launch",
-      "mode": "debug",
-      "program": "${workspaceFolder}/cmd/tctl",
-      "cwd": "${workspaceFolder}",
-      "args": [
-        "admin",
-        "wf",
-        "show"
-      ]
-    },
-    {
       "name": "temporalite:debug",
       "type": "go",
       "request": "launch",

--- a/cli_curr/adminCommands.go
+++ b/cli_curr/adminCommands.go
@@ -62,7 +62,7 @@ const maxEventID = 9999
 
 // AdminShowWorkflow shows history
 func AdminShowWorkflow(c *cli.Context) {
-	namespace := getRequiredGlobalOption(c, FlagNamespaceID)
+	namespaceId := getRequiredOption(c, FlagNamespaceID)
 	wid := getRequiredOption(c, FlagWorkflowID)
 	rid := getRequiredOption(c, FlagRunID)
 	startEventId := c.Int64(FlagMinEventID)
@@ -80,7 +80,7 @@ func AdminShowWorkflow(c *cli.Context) {
 	defer cancel()
 
 	resp, err := client.GetWorkflowExecutionRawHistoryV2(ctx, &adminservice.GetWorkflowExecutionRawHistoryV2Request{
-		NamespaceId: namespace,
+		NamespaceId: namespaceId,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: wid,
 			RunId:      rid,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

`tctl admin wf show  --namespace_id c61bddba-0450-4a4b-827f-fdd8578a9fd1 -w hello_world_workflowID -r a8b819e4-c9a3-4137-ba6a-e9fbd976d851` 

returns error "Error: Global option namespace_id is required" while `namespace_id` is not a global option.

With the fix, `tctl admin wf show` works again.


## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Manual test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
