### PR TITLE
DRAFT: Enabled WorkerVersioningId in DescribeTaskQueue output

### DIFF
--- a/cli/task_queue_commands.go
+++ b/cli/task_queue_commands.go
@@ -53,9 +53,7 @@ func DescribeTaskQueue(c *cli.Context) error {
 	}
 
 	opts := &output.PrintOptions{
-		// TODO enable when versioning feature is out
-		// Fields: []string{"Identity", "LastAccessTime", "RatePerSecond", "WorkerVersioningId"},
-		Fields: []string{"Identity", "LastAccessTime", "RatePerSecond"},
+		Fields: []string{"Identity", "LastAccessTime", "RatePerSecond", "WorkerVersioningId"},
 	}
 	var items []interface{}
 	for _, e := range resp.Pollers {


### PR DESCRIPTION
## What was changed
Add the WorkerVersioningId field in the output of `tctl task-queue describe`

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist

<!--- add/delete as needed --->

1. Closes 
https://github.com/temporalio/cli/issues/119

3. How was this tested:

TODO: is there any automated tests ? I cannot find it

5. Any docs updates needed?

Not sure, help needed from maintainers