### PR TITLE
Add TLS flag

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -70,6 +70,11 @@ func NewCliApp() *cli.App {
 			Usage:   "Authorization header to set for gRPC requests",
 			EnvVars: []string{"TEMPORAL_CLI_AUTH"},
 		},
+		&cli.BoolFlag{
+			Name:    FlagEnableTLS,
+			Usage:   "Enable TLS",
+			EnvVars: []string{"TEMPORAL_CLI_TLS"},
+		},
 		&cli.StringFlag{
 			Name:    FlagTLSCertPath,
 			Value:   "",

--- a/cli/factory.go
+++ b/cli/factory.go
@@ -205,6 +205,11 @@ func (b *clientFactory) createTLSConfig(c *cli.Context) (*tls.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to read TLS disable host verification flag: %w", err)
 	}
+	enableTLSS := c.String(FlagEnableTLS)
+	enableTLS, err := strconv.ParseBool(enableTLSS)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read TLS flag: %w", err)
+	}
 
 	serverName := c.String(FlagTLSServerName)
 
@@ -253,6 +258,17 @@ func (b *clientFactory) createTLSConfig(c *cli.Context) (*tls.Config, error) {
 	// If we are given a server name, set the TLS server name for DNS resolution
 	if serverName != "" {
 		host = serverName
+		tlsConfig := auth.NewTLSConfigForServer(host, !disableHostNameVerification)
+		return tlsConfig, nil
+	}
+	// If we are given a TLS flag, set the TLS server name from the address
+	if enableTLS {
+		hostPort := c.String(FlagAddress)
+		if hostPort == "" {
+			hostPort = localHostPort
+		}
+		// Ignoring error as we'll fail to dial anyway, and that will produce a meaningful error
+		host, _, _ = net.SplitHostPort(hostPort)
 		tlsConfig := auth.NewTLSConfigForServer(host, !disableHostNameVerification)
 		return tlsConfig, nil
 	}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -97,6 +97,7 @@ var (
 	FlagJobID                      = "job-id"
 	FlagYes                        = "yes"
 	FlagYesAlias                   = []string{"y"}
+	FlagEnableTLS                  = "tls"
 	FlagTLSCertPath                = "tls-cert-path"
 	FlagTLSKeyPath                 = "tls-key-path"
 	FlagTLSCaPath                  = "tls-ca-path"

--- a/cli_curr/app.go
+++ b/cli_curr/app.go
@@ -77,6 +77,11 @@ func NewCliApp() *cli.App {
 			Name:  FlagAutoConfirm,
 			Usage: "Automatically confirm all prompts",
 		},
+		cli.BoolFlag{
+			Name:   FlagEnableTLS,
+			Usage:  "Enable TLS",
+			EnvVar: "TEMPORAL_CLI_TLS",
+		},
 		cli.StringFlag{
 			Name:   FlagTLSCertPath,
 			Value:  "",

--- a/cli_curr/factory.go
+++ b/cli_curr/factory.go
@@ -184,6 +184,7 @@ func (b *clientFactory) createTLSConfig(c *cli.Context) (*tls.Config, error) {
 	caPath := c.GlobalString(FlagTLSCaPath)
 	disableHostNameVerification := c.GlobalBool(FlagTLSDisableHostVerification)
 	serverName := c.GlobalString(FlagTLSServerName)
+	enableTLS := c.GlobalBool(FlagEnableTLS)
 
 	var host string
 	var cert *tls.Certificate
@@ -230,6 +231,17 @@ func (b *clientFactory) createTLSConfig(c *cli.Context) (*tls.Config, error) {
 	// If we are given a server name, set the TLS server name for DNS resolution
 	if serverName != "" {
 		host = serverName
+		tlsConfig := auth.NewTLSConfigForServer(host, !disableHostNameVerification)
+		return tlsConfig, nil
+	}
+	// If we are given a TLS flag, set the TLS server name from the address
+	if enableTLS {
+		hostPort := c.GlobalString(FlagAddress)
+		if hostPort == "" {
+			hostPort = localHostPort
+		}
+		// Ignoring error as we'll fail to dial anyway, and that will produce a meaningful error
+		host, _, _ = net.SplitHostPort(hostPort)
 		tlsConfig := auth.NewTLSConfigForServer(host, !disableHostNameVerification)
 		return tlsConfig, nil
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
1. cli/app.go -> Added `--tls` flag to app.flags slice
2. cli/factory.go -> Added parsing `--tls` flag with checking on error. And added the logic that when the flag is activated, the host is taken from the address/localhost
3. cli/flags.go -> Added const of `--tls` flag name
4. cli_curr/app.go -> Added `--tls` flag to app.flags slice
5. cli_curr/factory.go -> Added parsing `--tls` flag with checking on error. And added the logic that when the flag is activated, the host is taken from the address/localhost



## Why?
I am connecting to my server over a TLS connection and I had to duplicate my host from the `--address` flag to the `--tls_server_name` flag. This cluttered up the command, as well as misleading.

## Checklist
<!--- add/delete as needed --->

1. Closes [#146](https://github.com/temporalio/tctl/issues/146)

4. How was this tested:
- By internal tests, but with adding this flag
- By connecting to local server with this flag

5. Any docs updates needed? - NO
