### PR TITLE
Fix namespace_id flag for AdminRefreshWorkflowTasks

### DIFF
--- a/cli_curr/adminCommands.go
+++ b/cli_curr/adminCommands.go
@@ -682,7 +682,7 @@ func AdminDescribeHistoryHost(c *cli.Context) {
 func AdminRefreshWorkflowTasks(c *cli.Context) {
 	adminClient := cFactory.AdminClient(c)
 
-	namespace := getRequiredGlobalOption(c, FlagNamespaceID)
+	namespaceId := getRequiredOption(c, FlagNamespaceID)
 	wid := getRequiredOption(c, FlagWorkflowID)
 	rid := c.String(FlagRunID)
 
@@ -690,7 +690,7 @@ func AdminRefreshWorkflowTasks(c *cli.Context) {
 	defer cancel()
 
 	_, err := adminClient.RefreshWorkflowTasks(ctx, &adminservice.RefreshWorkflowTasksRequest{
-		NamespaceId: namespace,
+		NamespaceId: namespaceId,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: wid,
 			RunId:      rid,


### PR DESCRIPTION
## What was changed

`tctl admin wf refresh_tasks --namespace_id tao.a2dd6 -w hello_world_workflowID-817677000`

returns error "Error: Global option namespace_id is required" while namespace_id is not a global option.

With the fix, tctl admin wf show works again.

Similar regression for another command: https://github.com/temporalio/tctl/pull/345

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Manual

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
