### PR TITLE
Set caller type header

### DIFF
--- a/cli/headers/headers.go
+++ b/cli/headers/headers.go
@@ -36,10 +36,12 @@ const (
 	SupportedServerVersionsHeaderName = "supported-server-versions"
 	SupportedFeaturesHeaderName       = "supported-features"
 	SupportedFeaturesHeaderDelim      = ","
+	CallerTypeHeaderName              = "caller-type"
 )
 
 const (
 	ClientNameCLI = "temporal-cli"
+	CallerTypeCLI = "operator"
 
 	CLIVersion = "1.18.0"
 
@@ -54,6 +56,7 @@ var (
 		ClientVersionHeaderName,
 		SupportedServerVersionsHeaderName,
 		SupportedFeaturesHeaderName,
+		CallerTypeHeaderName,
 	}
 
 	internalVersionHeaders = metadata.New(map[string]string{
@@ -62,6 +65,7 @@ var (
 
 	cliVersionHeaders = metadata.New(map[string]string{
 		ClientNameHeaderName:              ClientNameCLI,
+		CallerTypeHeaderName:              CallerTypeCLI,
 		ClientVersionHeaderName:           CLIVersion,
 		SupportedServerVersionsHeaderName: SupportedServerVersions,
 		// TODO: This should include SupportedFeaturesHeaderName with a value that's taken

--- a/cli/headersprovider/headers_provider.go
+++ b/cli/headersprovider/headers_provider.go
@@ -25,29 +25,27 @@ package headersprovider
 import (
 	"context"
 
+	"github.com/temporalio/tctl/cli/headers"
 	"github.com/temporalio/tctl/cli/plugin"
 )
-
-type HeadersProvider interface {
-	GetHeaders(context.Context) (map[string]string, error)
-}
 
 var (
 	headersProvider plugin.HeadersProvider = nil
 )
 
-type authHeaderProvider struct {
-	value string
+type headerProvider struct {
+	authHeaderValue string
 }
 
-func (a authHeaderProvider) GetHeaders(ctx context.Context) (map[string]string, error) {
+func (a headerProvider) GetHeaders(ctx context.Context) (map[string]string, error) {
 	return map[string]string{
-		"Authorization": a.value,
+		headers.CallerTypeHeaderName: headers.CallerTypeCLI,
+		"Authorization":              a.authHeaderValue,
 	}, nil
 }
 
 func SetAuthorizationHeader(value string) {
-	headersProvider = &authHeaderProvider{value: value}
+	headersProvider = &headerProvider{authHeaderValue: value}
 }
 
 func SetCurrent(hp plugin.HeadersProvider) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Setting `caller-type` header to `operator` for all outgoing requests
This indicates the server should give these requests higher priority when rate limiting
Depends on https://github.com/temporalio/temporal/pull/4623

## Why?
<!-- Tell your future self why have you made these changes -->
To improve user experience when trying to debug during rate limiting

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
