### PR TITLE
SDK-319: Updates `tctl` README for deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `tctl` CLI is now deprecated in favor of Temporal CLI. <br />
 This repository is no longer maintained. <br />
 Please use the new utility for all future development. <br />
 
-* New [`Temporal CLI` repository](https://github.com/temporalio/cli).
+* New [Temporal CLI repository](https://github.com/temporalio/cli).
 * [Temporal CLI Documentation site](https://docs.temporal.io/cli).
 
 # tctl

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is no longer maintained. <br />
 Please use the new utility for all future development. <br />
 
 * New [`Temporal CLI` repository](https://github.com/temporalio/cli).
-Documentation for Temporal CLI can be found at the [Temporal Documentation site](https://docs.temporal.io/cli).
+* [Temporal CLI Documentation site](https://docs.temporal.io/cli).
 
 # tctl
 tctl is a command-line tool that you can use to interact with a Temporal Cluster. It can perform Namespace operations (such as register, update, and describe) and Workflow operations (such as start Workflow, show Workflow History, and Signal Workflow).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The `tctl` CLI is now deprecated in favor of Temporal CLI. <br />
 This repository is no longer maintained. <br />
-Please use the new utility for all future development.<br />
+Please use the new utility for all future development. <br />
 Documentation for Temporal CLI can be found at the [Temporal Documentation site](https://docs.temporal.io/cli).
 
 # tctl

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `tctl` CLI is now deprecated in favor of Temporal CLI. <br />
 This repository is no longer maintained. <br />
 Please use the new utility for all future development. <br />
 
-New [`Temporal CLI` repository](https://github.com/temporalio/cli).
+* New [`Temporal CLI` repository](https://github.com/temporalio/cli).
 Documentation for Temporal CLI can be found at the [Temporal Documentation site](https://docs.temporal.io/cli).
 
 # tctl

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 The `tctl` CLI is now deprecated in favor of Temporal CLI. <br />
 This repository is no longer maintained. <br />
 Please use the new utility for all future development. <br />
+
+New [`Temporal CLI` repository](https://github.com/temporalio/cli).
 Documentation for Temporal CLI can be found at the [Temporal Documentation site](https://docs.temporal.io/cli).
 
 # tctl

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 [![build](https://github.com/temporalio/tctl/actions/workflows/test.yml/badge.svg)](https://github.com/temporalio/tctl/actions/workflows/test.yml)
 
-The public preview of [Temporal CLI](https://github.com/temporalio/cli) is now available. We encourage you to begin using it and to provide feedback.
+**:warning: Deprecation Notice :warning:**
 
-:warning: After the release of Temporal CLI v1.0, tctl will deprecate. :warning:
+The `tctl` CLI is now deprecated in favor of Temporal CLI. <br />
+This repository is no longer maintained. <br />
+Please use the new utility for all future development.<br />
+Documentation for Temporal CLI can be found at the [Temporal Documentation site](https://docs.temporal.io/cli).
 
 # tctl
 tctl is a command-line tool that you can use to interact with a Temporal Cluster. It can perform Namespace operations (such as register, update, and describe) and Workflow operations (such as start Workflow, show Workflow History, and Signal Workflow).


### PR DESCRIPTION
Visibly deprecates `tctl`. Adds caution note to README and redirect to docs for Temporal CLI.

After, repository needs to be archived.