### PR TITLE
Handle errors returned from NewTctlConfig

### DIFF
--- a/cmd/tctl/main.go
+++ b/cmd/tctl/main.go
@@ -35,10 +35,12 @@ import (
 
 // See https://docs.temporal.io/tctl/ for usage
 func main() {
-	tctlConfig, _ := config.NewTctlConfig()
+	tctlConfig, err := config.NewTctlConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
 	version := tctlConfig.Version
 
-	var err error
 	if version == "next" || version == "2" {
 		appNext := cli.NewCliApp()
 		err = appNext.Run(os.Args)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Handle errors from `config.NewTctlConfig()`. 

## Why?

Previously these errors would just result in a null pointer dereference error which isn't very helpful for solving whatever the issue may be.  I ran into this issue trying to use tctl in a pod with a read only root filesystem -- a common security setting.

```bash
# setup
❯ mkdir test
❯ sudo chown root test

# before -- v1.18.1
❯ HOME=./test ./tctl -h
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x101523c78]

goroutine 1 [running]:
main.main()
	/Users/tjmiller/src/tctl/cmd/tctl/main.go:39 +0x38

# after
❯ HOME=./test ./tctl -h
2024/12/04 09:28:37 mkdir test/.config: permission denied
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

To reproduce a `config.NewTctlConfig()` error Set the environment variable `HOME` either to an empty string or to a path you do not have access to.

3. Any docs updates needed?
no
